### PR TITLE
Remove chart numbering being artificially inflated by 1

### DIFF
--- a/app/views/forecast_snapshots/show.html.erb
+++ b/app/views/forecast_snapshots/show.html.erb
@@ -205,8 +205,8 @@
 
     for(i = 0; i < chart_data.length; i++) {
       // Create a div container for each chart
-      var n = i + 1; // Display/div number
-      $('div#charts_container').append('<div id="' + n + '"/>');
+      var chart_num = i + 1; // Display/div number
+      $('div#charts_container').append('<div id="' + chart_num + '"/>');
 
       // Set intervals and frequency. User to format xAxis labels and tooltips
       var interval, intervalUnit, dateLabel, frequency;
@@ -225,12 +225,12 @@
       }
 
       // Create a highchart for each series
-      $('#' + n).highcharts({
+      $('#' + chart_num).highcharts({
         chart: {
           alignTicks: false
         },
         title: {
-          text: n + '. ' + '<a href="http://data.uhero.hawaii.edu/#/series?id=' + chart_data[i].id + '" target="_blank">' + chart_data[i].title + ' (' + chart_data[i].series + ')' + '</a>',
+          text: chart_num + '. ' + '<a href="http://data.uhero.hawaii.edu/#/series?id=' + chart_data[i].id + '" target="_blank">' + chart_data[i].title + ' (' + chart_data[i].series + ')' + '</a>',
           align: 'left',
           useHTML: true,
           style: {

--- a/app/views/forecast_snapshots/show.html.erb
+++ b/app/views/forecast_snapshots/show.html.erb
@@ -205,7 +205,8 @@
 
     for(i = 0; i < chart_data.length; i++) {
       // Create a div container for each chart
-      $('div#charts_container').append('<div id="' + i + '"/>');
+      var n = i + 1; // Display/div number
+      $('div#charts_container').append('<div id="' + n + '"/>');
 
       // Set intervals and frequency. User to format xAxis labels and tooltips
       var interval, intervalUnit, dateLabel, frequency;
@@ -224,12 +225,12 @@
       }
 
       // Create a highchart for each series
-      $('#' + i).highcharts({
+      $('#' + n).highcharts({
         chart: {
           alignTicks: false
         },
         title: {
-          text: i + '. ' + '<a href="http://data.uhero.hawaii.edu/#/series?id=' + chart_data[i].id + '" target="_blank">' + chart_data[i].title + ' (' + chart_data[i].series + ')' + '</a>',
+          text: n + '. ' + '<a href="http://data.uhero.hawaii.edu/#/series?id=' + chart_data[i].id + '" target="_blank">' + chart_data[i].title + ' (' + chart_data[i].series + ')' + '</a>',
           align: 'left',
           useHTML: true,
           style: {

--- a/app/views/forecast_snapshots/show.html.erb
+++ b/app/views/forecast_snapshots/show.html.erb
@@ -229,7 +229,7 @@
           alignTicks: false
         },
         title: {
-          text: 1 + i + '. ' + '<a href="http://data.uhero.hawaii.edu/#/series?id=' + chart_data[i].id + '" target="_blank">' + chart_data[i].title + ' (' + chart_data[i].series + ')' + '</a>',
+          text: i + '. ' + '<a href="http://data.uhero.hawaii.edu/#/series?id=' + chart_data[i].id + '" target="_blank">' + chart_data[i].title + ' (' + chart_data[i].series + ')' + '</a>',
           align: 'left',
           useHTML: true,
           style: {


### PR DESCRIPTION
I have a vague memory that we deliberately added this "1 +" in order to get numbering to show correctly when we originally created the FS stuff (I say we bec I sorta remember the 3 of us being here and working on it together when we did that :). Not sure why it seemed right then, but wrong now.