### PR TITLE
Clickable names rather than "Show" link [superceded by UA-689]

### DIFF
--- a/app/views/data_lists/_form.html.erb
+++ b/app/views/data_lists/_form.html.erb
@@ -39,14 +39,13 @@
               %>
               <tr>
                 <td><%= measurement.prefix %></td>
-                <td><span class="indentation"><%= make_indentation(indent_i) %></span><%= measurement.data_portal_name %></td>
+                <td><span class="indentation"><%= make_indentation(indent_i) %></span><%= link_to measurement.data_portal_name, measurement %></td>
                 <td><%= link_to 'Up', {controller: :data_lists, action: :move_measurement_up, id: @data_list, measurement_id: measurement.id}, remote: true, data: {up: true} %></td>
                 <td><%= link_to 'Down', {controller: :data_lists, action: :move_measurement_down, id: @data_list, measurement_id: measurement.id}, remote: true, data: {down: true} %></td>
                 <td><%= link_to '<<'.html_safe, {controller: :data_lists, action: :set_measurement_indent, id: @data_list, measurement_id: measurement.id, indent_in_out: 'out'}, remote: true, data: {indent: 1} %></td>
                 <td><%= link_to '>>'.html_safe, {controller: :data_lists, action: :set_measurement_indent, id: @data_list, measurement_id: measurement.id, indent_in_out: 'in'}, remote: true, data: {indent: 1} %></td>
 
                 <td><%= link_to 'Duplicate', duplicate_measurement_path(measurement) %></td>
-                <td><%= link_to 'Show', measurement %></td>
                 <td><%= link_to 'Edit', edit_measurement_path(measurement) %></td>
                 <td><%= link_to 'Remove', {controller: :data_lists, action: :remove_measurement, id: @data_list, measurement_id: measurement.id}, remote: true, data: {remove: true} %></td>
               </tr>

--- a/app/views/data_lists/index.html.erb
+++ b/app/views/data_lists/index.html.erb
@@ -14,7 +14,7 @@
 
 <% @data_lists.order(:name).each do |data_list| %>
   <tr>
-    <td><%= data_list.name %></td>
+    <td><%= link_to data_list.name, :action => 'super_table', :id => data_list %></td>
     <td><%= data_list.measurements.count %></td>
     <td><%= link_to 'FlexTable', :action => 'super_table', :id => data_list %></td>
     <% if current_user.admin_user? || data_list.owned_by == current_user.id %>

--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -16,10 +16,9 @@
   <tbody>
     <% @exports.each do |export| %>
       <tr>
-        <td><%= export.name %></td>
+        <td><%= link_to export.name, export %></td>
         <td><%= export.series.count %></td>
         <td><%= link_to 'CSV', action: 'show', id: export, format: 'csv' %></td>
-        <td><%= link_to 'Show', export %></td>
         <td><%= link_to 'Table', action: 'show_table', id: export %></td>
         <td><%= link_to 'Edit', edit_export_path(export) %></td>
         <td><%= link_to 'Destroy', export, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/forecast_snapshots/index.html.erb
+++ b/app/views/forecast_snapshots/index.html.erb
@@ -26,7 +26,7 @@
   <tbody>
     <% @forecast_snapshots.each do |fs| %>
       <tr>
-        <td><%= fs.name %></td>
+        <td><%= link_to fs.name, fs %></td>
         <td align="center"><%= fs.version %></td>
         <td><%= fs.comments %></td>
         <% if current_user.internal_user? %>
@@ -34,7 +34,6 @@
         <% end %>
         <td><%= fs.created_at.localtime.strftime("%m/%d/%y") %></td>
         <td><%= fs.updated_at.localtime.strftime("%m/%d/%y") %></td>
-        <td><%= link_to 'Show', fs %></td>
         <% if current_user.admin_user? %>
            <td><%= link_to 'Edit', edit_forecast_snapshot_path(fs) %></td>
         <% end %>

--- a/app/views/measurements/index.html.erb
+++ b/app/views/measurements/index.html.erb
@@ -28,13 +28,12 @@
     <% @measurements.each do |measurement| %>
       <tr>
         <td><%= measurement.prefix %></td>
-        <td><%= measurement.data_portal_name %></td>
+        <td><%= link_to measurement.data_portal_name, measurement %></td>
         <td><%= measurement.units_label %></td>
         <td><%= measurement.units_label_short %></td>
         <td><%= measurement.percent %></td>
         <td><%= measurement.real %></td>
         <td><%= measurement.notes %></td>
-        <td><%= link_to 'Show', measurement %></td>
         <td><%= link_to 'Edit', edit_measurement_path(measurement) %></td>
         <td><%= link_to 'Duplicate', duplicate_measurement_path(measurement) %></td>
       </tr>

--- a/app/views/source_details/index.html.erb
+++ b/app/views/source_details/index.html.erb
@@ -13,8 +13,7 @@
   <tbody>
     <% @source_details.each do |source_detail| %>
       <tr>
-        <td><%= source_detail.description %></td>
-        <td><%= link_to 'Show', source_detail %></td>
+        <td><%= link_to source_detail.description, source_detail %></td>
         <td><%= link_to 'Edit', edit_source_detail_path(source_detail) %></td>
         <td><%= link_to 'Destroy', source_detail, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/sources/index.html.erb
+++ b/app/views/sources/index.html.erb
@@ -17,9 +17,8 @@
   <tbody>
     <% @sources.each do |source| %>
       <tr>
-        <td><%= source.description %></td>
+        <td><%= link_to source.description, source %></td>
         <td><%= source.link %></td>
-        <td><%= link_to 'Show', source %></td>
         <td><%= link_to 'Edit', edit_source_path(source) %></td>
         <td><%= link_to 'Destroy', source, method: :delete, data: { confirm: "Destroy #{source.description}: Are you sure??" } %></td>
       </tr>


### PR DESCRIPTION
At the meeting I remembered that I had promised this to Carl last time, and now felt like a good time to bang it out :=) The only thing I don't much like about the result is the way the underlining of the links clashes a bit with the light gray underlines that go all the way across to separate the entries (maybe this is easy to fix in the css). But it seems like a big win usability-wise. I think I hit more or less all the places where it would be needed.