### PR TITLE
Bug: Download cache breaks when handle == 'manual'

### DIFF
--- a/lib/download/downloads_cache.rb
+++ b/lib/download/downloads_cache.rb
@@ -42,6 +42,7 @@ class DownloadsCache
   end
 
   def mark_handle_used(handle)
+    return unless handle =~ /@/
     @cache[:used_dloads][handle] = @cache[:dloads][handle] || raise("No download handle #{handle} to mark")
   end
 


### PR DESCRIPTION
I think this will do the trick. I ran a bunch of tests of both `load_from_file` and `load_from_download` (the only Series methods that use this code) and all seemed to work (also confirmed breakage without this one-line fix).