### PR TITLE
Population of Geographies foreign key in Series model (UA-717)

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -16,7 +16,7 @@ class SeriesController < ApplicationController
   def create
     begin
       @series = Series.create_new(series_params.merge(other_params))
-    rescue SeriesNameException, StandardError => error
+    rescue => error
       redirect_to({ :action => :new }, :notice => error.message)
       return
     end

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -14,17 +14,12 @@ class SeriesController < ApplicationController
 
   # POST /series
   def create
-    name_parts = params[:name_parts]
-    if name_parts[:name_prefix].blank?
+    if series_params[:name_parts][:name_prefix].blank?
       redirect_to({:action => :new}, :notice => 'Series NOT SAVED - empty prefix')
       return
     end
-    geo_id = name_parts[:name_geo_id]
-    geo = Geography.find(geo_id) || raise('No geography found for series creation')
-    @series = Series.new(series_params.except(:name_parts)
-                             .merge(name: build_name(name_parts.merge(geo: geo.handle)))
-                             .merge(geography_id: geo_id))
-    if @series.save
+    @series = Series.create_new(series_params)
+    if @series
       redirect_to @series, notice: 'Series was successfully created.'
     else
       render :new
@@ -301,10 +296,6 @@ class SeriesController < ApplicationController
           :source_detail_id
       )
     end
-
-  def build_name(parts)
-    parts[:name_prefix].strip + '@' + parts[:geo] + '.' + parts[:name_freq]
-  end
 
   def convert_to_udaman_notation(eval_string)
       operator_fix = eval_string.gsub('(','( ').gsub(')', ' )').gsub('*',' * ').gsub('/',' / ').gsub('-',' - ').gsub('+',' + ')

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -14,11 +14,12 @@ class SeriesController < ApplicationController
 
   # POST /series
   def create
-    if other_params[:name_parts][:name_prefix].blank?
-      redirect_to({:action => :new}, :notice => 'Series NOT SAVED - empty prefix')
+    begin
+      @series = Series.create_new(series_params.merge(other_params))
+    rescue => error
+      redirect_to({ :action => :new }, :notice => error.message)
       return
     end
-    @series = Series.create_new(series_params.merge(other_params))
     if @series
       redirect_to @series, notice: 'Series was successfully created.'
     else
@@ -297,7 +298,7 @@ class SeriesController < ApplicationController
     end
 
   def other_params
-    params.permit(name_parts: [:name_prefix, :name_geo_id, :name_freq])
+    params.permit(name_parts: [:prefix, :geo_id, :freq])
   end
 
   def convert_to_udaman_notation(eval_string)

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -16,7 +16,7 @@ class SeriesController < ApplicationController
   def create
     begin
       @series = Series.create_new(series_params.merge(other_params))
-    rescue => error
+    rescue SeriesNameException, StandardError => error
       redirect_to({ :action => :new }, :notice => error.message)
       return
     end

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -14,11 +14,11 @@ class SeriesController < ApplicationController
 
   # POST /series
   def create
-    if series_params[:name_parts][:name_prefix].blank?
+    if other_params[:name_parts][:name_prefix].blank?
       redirect_to({:action => :new}, :notice => 'Series NOT SAVED - empty prefix')
       return
     end
-    @series = Series.create_new(series_params)
+    @series = Series.create_new(series_params.merge(other_params))
     if @series
       redirect_to @series, notice: 'Series was successfully created.'
     else
@@ -279,7 +279,6 @@ class SeriesController < ApplicationController
   private
     def series_params
       params.require(:series).permit(
-          :name_parts,
           :description,
           :units,
           :investigation_notes,
@@ -296,6 +295,10 @@ class SeriesController < ApplicationController
           :source_detail_id
       )
     end
+
+  def other_params
+    params.permit(name_parts: [:name_prefix, :name_geo_id, :name_freq])
+  end
 
   def convert_to_udaman_notation(eval_string)
       operator_fix = eval_string.gsub('(','( ').gsub(')', ' )').gsub('*',' * ').gsub('/',' / ').gsub('-',' - ').gsub('+',' + ')

--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -227,7 +227,7 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
       prefix = "DBEDT_#{row[0]}"
       region = row[3].strip
       (geo_handle, geo_fips) = get_geo_handle(region)
-      name = prefix + '@' + geo_handle + '.' + row[4]
+      name = Series.build_name([ prefix, geo_handle, row[4] ])
       if current_measurement.nil? || current_measurement.prefix != prefix
         current_measurement = Measurement.find_by prefix: prefix
         if current_measurement.nil?

--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -241,7 +241,8 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
 
       if current_series.nil? || current_series.name != name
         # need a fresh data_source for each series unless I make series - data_sources a many-to-many relationship
-        source_id = Source.get_or_new(row[9], nil, 'DBEDT').id
+        source_str = row[9] && row[9].to_ascii.strip
+        source = (source_str.blank? || source_str.downcase == 'none') ? nil : Source.get_or_new(source_str, nil, 'DBEDT')
         geo_id = Geography.get_or_new_dbedt({ handle: geo_handle },
                                             { fips: geo_fips, display_name: region, display_name_short: region}).id
         unit_str = row[8] && row[8].to_ascii.strip
@@ -259,7 +260,7 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
               unit_id: unit && unit.id,
               unitsLabel: unit_str,
               unitsLabelShort: unit_str,
-              source_id: source_id,
+              source_id: source && source.id,
               decimals: row[10],
               units: 1
           )

--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -218,7 +218,7 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
       return true
     end
 
-    geo_id = Geography.find_by(universe: 'DBEDT').first.id
+    geo_id = Geography.find_by(universe: 'DBEDT').first.id rescue raise('No DBEDT geography found')
 
     logger.debug { 'loading DBEDT data' }
     current_series = nil

--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -226,7 +226,7 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
     CSV.foreach(series_csv_path, {col_sep: "\t", headers: true, return_headers: false}) do |row|
       prefix = "DBEDT_#{row[0]}"
       region = row[3].strip
-      (geo_handle, geo_fips) = get_geo_handle(region)
+      (geo_handle, geo_fips) = get_geo_codes(region)
       name = Series.build_name([ prefix, geo_handle, row[4] ])
       if current_measurement.nil? || current_measurement.prefix != prefix
         current_measurement = Measurement.find_by prefix: prefix
@@ -244,6 +244,9 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
         source_id = Source.get_or_new_dbedt(row[9]).id
         geo_id = Geography.get_or_new_dbedt({ handle: geo_handle },
                                             { fips: geo_fips, display_name: region, display_name_short: region}).id
+        unit_str = row[8] && row[8].to_ascii.strip
+        unit = (unit_str.blank? || unit_str.downcase == 'none') ? nil : Unit.get_or_new_dbedt(unit_str)
+
         current_series = Series.find_by name: name
         if current_series.nil?
           current_series = Series.create(
@@ -253,13 +256,17 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
               geography_id: geo_id,
               description: row[1],
               dataPortalName: row[1],
-              unitsLabel: row[8],
-              unitsLabelShort: row[8],
+              unit_id: unit && unit.id,
+              unitsLabel: unit_str,
+              unitsLabelShort: unit_str,
               source_id: source_id,
-              measurement_id: current_measurement.id,
               decimals: row[10],
               units: 1
           )
+        end
+        if current_measurement.series.where(id: current_series.id).empty?
+          current_measurement.series << current_series
+          logger.debug { "added series #{current_series.name} to measurement #{current_measurement.prefix}" }
         end
         current_data_source = DataSource.find_by eval: "DbedtUpload.load(#{id}, #{current_series.id})"
         if current_data_source.nil?
@@ -355,7 +362,7 @@ WHERE data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE 'DbedtUploa
     DataSource.where("eval LIKE 'DbedtUpload.load(#{self.id},%)'").delete_all
   end
 
-  def get_geo_handle(name)
+  def get_geo_codes(name)
     handles = {
         'hawaii county' => ['HAW', 15001],
         'honolulu county' => ['HON', 15003],

--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -218,6 +218,8 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
       return true
     end
 
+    geo_id = Geography.find_by(universe: 'DBEDT').first.id
+
     logger.debug { 'loading DBEDT data' }
     current_series = nil
     current_data_source = nil
@@ -246,6 +248,7 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
               universe: 'DBEDT',
               name: name,
               frequency: row[4],
+              geography_id: geo_id,
               description: row[1],
               dataPortalName: row[1],
               unitsLabel: row[8],

--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -241,11 +241,11 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
 
       if current_series.nil? || current_series.name != name
         # need a fresh data_source for each series unless I make series - data_sources a many-to-many relationship
-        source_id = Source.get_or_new_dbedt(row[9]).id
+        source_id = Source.get_or_new(row[9], nil, 'DBEDT').id
         geo_id = Geography.get_or_new_dbedt({ handle: geo_handle },
                                             { fips: geo_fips, display_name: region, display_name_short: region}).id
         unit_str = row[8] && row[8].to_ascii.strip
-        unit = (unit_str.blank? || unit_str.downcase == 'none') ? nil : Unit.get_or_new_dbedt(unit_str)
+        unit = (unit_str.blank? || unit_str.downcase == 'none') ? nil : Unit.get_or_new(unit_str, 'DBEDT')
 
         current_series = Series.find_by name: name
         if current_series.nil?

--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -218,7 +218,7 @@ WHERE data_points.data_source_id IN (SELECT id FROM data_sources WHERE eval LIKE
       return true
     end
 
-    geo_id = Geography.find_by(universe: 'DBEDT').first.id rescue raise('No DBEDT geography found')
+    geo_id = Geography.find_by(universe: 'DBEDT').id rescue raise('No DBEDT geography found')
 
     logger.debug { 'loading DBEDT data' }
     current_series = nil

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -1,6 +1,11 @@
 class Geography < ActiveRecord::Base
   has_many :series
 
+  def Geography.get_or_new_dbedt(attrs, add_attrs = {})
+    attrs.merge!(universe: 'DBEDT')
+    Geography.find_by(attrs) || Geography.create(attrs.merge(add_attrs))
+  end
+
   def Geography.get_or_new_nta(attrs, add_attrs = {})
     attrs.merge!(universe: 'NTA')
     geo = Geography.find_by(attrs)

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -1,4 +1,5 @@
 class Geography < ActiveRecord::Base
+  has_many :series
 
   def Geography.get_or_new_nta(attrs, add_attrs = {})
     attrs.merge!(universe: 'NTA')

--- a/app/models/nta_upload.rb
+++ b/app/models/nta_upload.rb
@@ -132,7 +132,7 @@ class NtaUpload < ActiveRecord::Base
 
       ## units
       unit_str = row[3] && row[3].to_ascii.strip
-      unit = (unit_str.blank? || unit_str.downcase == 'none') ? nil : Unit.get_or_new_nta(unit_str)
+      unit = (unit_str.blank? || unit_str.downcase == 'none') ? nil : Unit.get_or_new(unit_str, 'NTA')
 
       ## percent
       percent = row[5] =~ /growth rate/i ? false : true
@@ -145,7 +145,7 @@ class NtaUpload < ActiveRecord::Base
         desc = ($1 && !$1.blank?) ? $1.to_ascii.strip : nil
         link = ($2 && !$2.blank?) ? $2.to_ascii.strip : nil
       end
-      source = (desc || link) ? Source.get_or_new_nta(desc, link) : nil
+      source = (desc || link) ? Source.get_or_new(desc, link, 'NTA') : nil
 
       ## measurement
       measurement = Measurement.find_by(universe: 'NTA', prefix: data_list_name)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -266,7 +266,6 @@ class Series < ActiveRecord::Base
               raise("No UHERO geography (handle=#{name_parts[:geo]}) found for series creation")
     end
     properties[:name] = Series.build_name([ name_parts[:prefix], geo.handle, name_parts[:freq] ])
-    raise("Series name '#{properties[:name]}' format invalid") unless Series.parse_name(properties[:name])
     properties[:geography_id] = geo.id
     properties[:frequency] = Series.frequency_from_code(name_parts[:freq])
     Series.create( properties.map {|k,v| [k, v.blank? ? nil : v] }.to_h ) ## don't put empty strings in the db.
@@ -281,10 +280,8 @@ class Series < ActiveRecord::Base
   end
 
   def Series.build_name(parts)
-    if parts[0].blank? || parts[1].blank? || parts[2].blank?
-      raise SeriesNameException, 'Build series name: one or more parts is blank'
-    end
-    parts[0].strip + '@' + parts[1].strip + '.' + parts[2].strip
+    name = parts[0].strip + '@' + parts[1].strip + '.' + parts[2].strip
+    Series.parse_name(name) ? name : raise("Build series name: '#{name}' format invalid")
   end
 
   def Series.store(series_name, series, desc=nil, eval_statement=nil, priority=100)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -280,7 +280,9 @@ class Series < ActiveRecord::Base
   end
 
   def Series.build_name(parts)
-    raise 'Build series name: one or more parts is blank' if parts[0].blank? || parts[1].blank? || parts[2].blank?
+    if parts[0].blank? || parts[1].blank? || parts[2].blank?
+      raise SeriesNameException, 'Build series name: one or more parts is blank'
+    end
     parts[0].strip + '@' + parts[1].strip + '.' + parts[2].strip
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -228,14 +228,14 @@ class Series < ActiveRecord::Base
   
   def Series.load_all_series_from(spreadsheet_path, sheet_to_load = nil, priority = 100)
     t = Time.now
-    # puts "Setting priority to #{priority}"
     each_spreadsheet_header(spreadsheet_path, sheet_to_load, false) do |series_name, update_spreadsheet|
-      @data_source = Series.store(series_name, Series.new(:frequency => update_spreadsheet.frequency, :data => update_spreadsheet.series(series_name)), spreadsheet_path, %Q^"#{series_name}".tsn.load_from "#{spreadsheet_path}", "#{sheet_to_load}"^) unless sheet_to_load.nil?
-      @data_source = Series.store(series_name, Series.new(:frequency => update_spreadsheet.frequency, :data => update_spreadsheet.series(series_name)), spreadsheet_path, %Q^"#{series_name}".tsn.load_from "#{spreadsheet_path}"^) if sheet_to_load.nil?      
-      #puts series_name
+      eval_format = sheet_to_load ? '"%s".tsn.load_from "%s", "%s"' : '"%s".tsn.load_from "%s"'
+      @data_source = Series.store(series_name,
+                                  Series.new(frequency: update_spreadsheet.frequency, data: update_spreadsheet.series(series_name)),
+                                  spreadsheet_path,
+                                  eval_format % [series_name, spreadsheet_path, sheet_to_load])
+
       @data_source.update_attributes(:priority => priority)
-      # puts "Series Name: #{series_name}"
-      # puts "priority: #{priority}, ds_id: #{@data_source.id} "
       series_name
     end
     puts "#{'%.2f' % (Time.now - t)} : #{spreadsheet_path}"

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -262,9 +262,9 @@ class Series < ActiveRecord::Base
       geo = Geography.find(geo_id) || raise("No geography (id=#{geo_id}) found for series creation")
       properties[:geography_id] = geo_id
       properties[:frequency] = Series.frequency_from_code(name_parts[:name_freq])
-      properties[:name] = Series.build_series_name([ name_parts[:name_prefix], geo.handle, name_parts[:name_freq] ])
+      properties[:name] = Series.build_name([ name_parts[:name_prefix], geo.handle, name_parts[:name_freq] ])
     else
-      name_parts = Series.parse_series_name(properties[:name]) || raise("Series name #{properties[:name]} not parseable")
+      name_parts = Series.parse_name(properties[:name]) || raise("Series name #{properties[:name]} not parseable")
       geo = Geography.find_by(universe: 'UHERO', handle: name_parts[:geo]) ||
               raise("No UHERO geography (handle=#{name_parts[:geo]}) found for series creation")
       properties[:geography_id] = geo.id
@@ -273,12 +273,16 @@ class Series < ActiveRecord::Base
     Series.create(properties)
   end
 
-  def Series.parse_series_name(name)
+  def Series.parse_name(name)
     name =~ /^(.+?)@(\w+?)\.([ASQMWDasqmwd])$/ ? { prefix: $1, geo: $2, freq: $3.upcase } : nil
   end
 
-  def Series.build_series_name(parts)
-    parts[0].strip + '@' + parts[1] + '.' + parts[2]
+  def parse_name
+    name =~ /^(.+?)@(\w+?)\.([ASQMWDasqmwd])$/ ? { prefix: $1, geo: $2, freq: $3.upcase } : nil
+  end
+
+  def Series.build_name(parts)
+    parts[0].strip + '@' + parts[1].strip + '.' + parts[2].strip
   end
 
   def Series.store(series_name, series, desc=nil, eval_statement=nil, priority=100)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -25,6 +25,7 @@ class Series < ActiveRecord::Base
   belongs_to :source, inverse_of: :series
   belongs_to :source_detail, inverse_of: :series
   belongs_to :unit, inverse_of: :series
+  belongs_to :geography, inverse_of: :series
 
   has_many :measurement_series, dependent: :delete_all
   has_many :measurements, through: :measurement_series

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -2,16 +2,10 @@ class Source < ActiveRecord::Base
   has_many :series
   has_many :measurements
 
-  def Source.get_or_new_dbedt(description, link = nil)
-    Source.find_by(universe: 'DBEDT', description: description) ||
-    (link && Source.find_by(universe: 'DBEDT', link: link)) ||
-    Source.create(universe: 'DBEDT', description: description, link: link)
-  end
-
-  def Source.get_or_new_nta(description, link = nil)
-    Source.find_by(universe: 'NTA', description: description) ||
-    (link && Source.find_by(universe: 'NTA', link: link)) ||
-    Source.create(universe: 'NTA', description: description, link: link)
+  def Source.get_or_new(description, link = nil, universe = 'UHERO')
+    Source.find_by(universe: universe, description: description) ||
+    (link && Source.find_by(universe: universe, link: link)) ||
+    Source.create(universe: universe, description: description, link: link)
   end
 
 end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -7,6 +7,11 @@ class Unit < ActiveRecord::Base
     ('%s (%s)' % [long_label, short_label]).html_safe
   end
 
+  def Unit.get_or_new_dbedt(label)
+    Unit.find_by(universe: 'DBEDT', short_label: label) ||
+     Unit.create(universe: 'DBEDT', short_label: label, long_label: label)
+  end
+
   def Unit.get_or_new_nta(label)
     Unit.find_by(universe: 'NTA', short_label: label) ||
      Unit.create(universe: 'NTA', short_label: label, long_label: label)

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -7,14 +7,9 @@ class Unit < ActiveRecord::Base
     ('%s (%s)' % [long_label, short_label]).html_safe
   end
 
-  def Unit.get_or_new_dbedt(label)
-    Unit.find_by(universe: 'DBEDT', short_label: label) ||
-     Unit.create(universe: 'DBEDT', short_label: label, long_label: label)
-  end
-
-  def Unit.get_or_new_nta(label)
-    Unit.find_by(universe: 'NTA', short_label: label) ||
-     Unit.create(universe: 'NTA', short_label: label, long_label: label)
+  def Unit.get_or_new(label, universe = 'UHERO')
+    Unit.find_by(universe: universe, short_label: label) ||
+     Unit.create(universe: universe, short_label: label, long_label: label)
   end
 
   private

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -15,7 +15,7 @@
       <div class="field">
         <%= f.label :name, 'Name: Prefix' %><br/>
         <%= text_field_tag 'name_parts[name_prefix]', nil, :size => 20 %> @
-        <%= select :name_parts, :name_geo, Geography.where(universe: 'UHERO').all.collect {|g| [ g.handle, g.handle ] }, {:include_blank => false} %> .
+        <%= select :name_parts, :name_geo_id, Geography.where(universe: 'UHERO').all.collect {|g| ['%s (%s)' % [g.handle, g.display_name_short], g.id] }, {:include_blank => false} %> .
         <%= select :name_parts, :name_freq, %w(A Q M W S D).collect {|x| [x, x] }, {:include_blank => false} %>
       </div>
     <% end %>

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -14,9 +14,9 @@
     <% if request.path !~ /edit/ %>
       <div class="field">
         <%= f.label :name, 'Name: Prefix' %><br/>
-        <%= text_field_tag 'name_parts[name_prefix]', nil, :size => 20 %> @
-        <%= select :name_parts, :name_geo_id, Geography.where(universe: 'UHERO').collect {|g| ['%s (%s)' % [g.handle, g.display_name_short], g.id] }, {:include_blank => false} %> .
-        <%= select :name_parts, :name_freq, %w(A Q M W S D).collect {|x| [x, x] }, {:include_blank => false} %>
+        <%= text_field_tag 'name_parts[prefix]', nil, :size => 20 %> @
+        <%= select :name_parts, :geo_id, Geography.where(universe: 'UHERO').collect {|g| ['%s (%s)' % [g.handle, g.display_name_short], g.id] }, {:include_blank => false} %> .
+        <%= select :name_parts, :freq, %w(A Q M W S D).collect {|x| [x, x] }, {:include_blank => false} %>
       </div>
     <% end %>
     <div class="field">

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -15,7 +15,7 @@
       <div class="field">
         <%= f.label :name, 'Name: Prefix' %><br/>
         <%= text_field_tag 'name_parts[name_prefix]', nil, :size => 20 %> @
-        <%= select :name_parts, :name_geo_id, Geography.where(universe: 'UHERO').all.collect {|g| ['%s (%s)' % [g.handle, g.display_name_short], g.id] }, {:include_blank => false} %> .
+        <%= select :name_parts, :name_geo_id, Geography.where(universe: 'UHERO').collect {|g| ['%s (%s)' % [g.handle, g.display_name_short], g.id] }, {:include_blank => false} %> .
         <%= select :name_parts, :name_freq, %w(A Q M W S D).collect {|x| [x, x] }, {:include_blank => false} %>
       </div>
     <% end %>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -48,6 +48,7 @@ google.visualization.events.addListener(chart, 'select', function() {
     </td></tr>
     <tr><td>Data Portal Name</td><td><%= @series.dataPortalName %></td></tr>
     <tr><td>Units</td><td><%= @series.unit.to_s if @series.unit %></td></tr>
+    <tr><td>Geography</td><td><%= @series.geography ? @series.geography.display_name : '<span style="color:red;">Not linked</span>'.html_safe %></td></tr>
     <tr><td>Decimals</td><td><%= @series.decimals.to_s %></td></tr>
     <tr><td>Base Year</td><td><%= @series.base_year %></td></tr>
     <tr><td>Seasonal Adjustment</td><td><%= @series[:seasonal_adjustment].to_s %></td></tr>

--- a/spec/controllers/geographies_controller_spec.rb
+++ b/spec/controllers/geographies_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GeographiesController, type: :controller do
   # Geography. As you add validations to Geography, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) {
-    {fips: '15001', display_name: 'City and County of Honolulu', display_name_short: 'Honolulu', handle: 'HNL'}
+    {universe: 'UHERO', fips: '15001', display_name: 'City and County of Honolulu', display_name_short: 'Honolulu', handle: 'HNL'}
   }
 
   let(:invalid_attributes) {
@@ -104,7 +104,7 @@ RSpec.describe GeographiesController, type: :controller do
   describe 'PUT #update' do
     context 'with valid params' do
       let(:new_attributes) {
-        {fips: '15', display_name: 'State of Hawaii', display_name_short: 'Hawaii', handle: 'HI'}
+        {universe: 'UHERO', fips: '15', display_name: 'State of Hawaii', display_name_short: 'Hawaii', handle: 'HI'}
       }
 
       it 'updates the requested geography' do

--- a/spec/lib/series_relationship_spec.rb
+++ b/spec/lib/series_relationship_spec.rb
@@ -4,6 +4,11 @@ require 'spec_helper'
 #try several different create statements
 #time results from creating
 describe SeriesRelationship do
+  before(:all) do
+    Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+    Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
+  end
+
   describe "CLEANING DATA SOURCE operations" do
   
     before (:each) do

--- a/spec/lib/series_relationship_spec.rb
+++ b/spec/lib/series_relationship_spec.rb
@@ -6,8 +6,13 @@ require 'spec_helper'
 describe SeriesRelationship do
   before(:all) do
     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
     Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
-    Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Honolulu' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
+    Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
+    Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Meeting Place' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
   end
 

--- a/spec/lib/series_relationship_spec.rb
+++ b/spec/lib/series_relationship_spec.rb
@@ -5,20 +5,22 @@ require 'spec_helper'
 #time results from creating
 describe SeriesRelationship do
   before(:all) do
-    Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
-    Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
-    Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
-    Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Meeting Place' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
-    Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
   end
 
   describe "CLEANING DATA SOURCE operations" do
   
     before (:each) do
+      Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
+      Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
+      Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
+      Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
+      Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
+      Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
       Series.load_all_series_from "#{ENV["DATAFILES_PATH"]}/datafiles/specs/ECT.xls"
     end
   

--- a/spec/lib/series_relationship_spec.rb
+++ b/spec/lib/series_relationship_spec.rb
@@ -6,6 +6,8 @@ require 'spec_helper'
 describe SeriesRelationship do
   before(:all) do
     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+    Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
+    Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Honolulu' }) rescue nil
     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
   end
 

--- a/spec/lib/series_relationship_spec.rb
+++ b/spec/lib/series_relationship_spec.rb
@@ -11,15 +11,10 @@ describe SeriesRelationship do
   
     before (:each) do
       Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
       Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
       Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
       Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
       Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
       Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
       Series.load_all_series_from "#{ENV["DATAFILES_PATH"]}/datafiles/specs/ECT.xls"
     end

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -5,6 +5,9 @@ require 'spec_helper'
 
 describe DataSource do
   before(:all) do
+    Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+    Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
+
     @data1_hash = "YSTWTR@HI.A".tsn.load_from("#{ENV["DATAFILES_PATH"]}/datafiles/specs/gsp_upd.xls").data
     @data1_no_nil = @data1_hash.clone
     @data1_no_nil.delete_if {|key,value| value.nil?}

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -6,8 +6,16 @@ require 'spec_helper'
 describe DataSource do
   before(:all) do
     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
+    Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
+    Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
+    Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
+    Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
-
     @data1_hash = "YSTWTR@HI.A".tsn.load_from("#{ENV["DATAFILES_PATH"]}/datafiles/specs/gsp_upd.xls").data
     @data1_no_nil = @data1_hash.clone
     @data1_no_nil.delete_if {|key,value| value.nil?}
@@ -16,7 +24,21 @@ describe DataSource do
     @data2_no_nil = @data2_hash.clone
     @data2_no_nil.delete_if {|key,value| value.nil?}
   end
-    
+
+  before(:each) do
+    Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
+    Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
+    Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
+    Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
+    Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
+    Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
+  end
+
   xit "should create a source when append syntax is used" do
     "YSTWTR@HI.A".ts_append_eval %Q|"YSTWTR@HI.A".tsn.load_from "#{ENV["DATAFILES_PATH"]}/datafiles/specs/gsp_upd.xls"|
     "YSTWTR@HI.A".ts.data_sources.count.should == 1

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -6,15 +6,10 @@ require 'spec_helper'
 describe DataSource do
   before(:all) do
     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
     Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
     Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
     Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
     Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
     @data1_hash = "YSTWTR@HI.A".tsn.load_from("#{ENV["DATAFILES_PATH"]}/datafiles/specs/gsp_upd.xls").data
     @data1_no_nil = @data1_hash.clone
@@ -27,15 +22,10 @@ describe DataSource do
 
   before(:each) do
     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
     Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
     Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
     Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
     Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
   end
 

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -9,15 +9,10 @@ describe Series do
 
   before(:each) do
     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
     Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
     Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
     Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
     Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
-    Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
   end
 
@@ -348,15 +343,10 @@ describe Series do
   describe "DATA POINT dynamics" do    
     before(:all) do
       Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
       Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
       Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
       Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
       Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
-      Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
       Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
       @data_hash = "EIFNS@HI.M".tsn.load_from("#{ENV["DATAFILES_PATH"]}/datafiles/ns_update.xls").data
       @data_no_nil = @data_hash.clone

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -5,8 +5,8 @@ describe Series do
   before(:all) do
      @dh = get_data_hash
      @data_files_path = "#{ENV["DATAFILES_PATH"]}/datafiles/"
-     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' })
-     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' })
+     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
    end
    
   describe "reporting OBSERVATION COUNTS" do

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -3,10 +3,10 @@ require 'spec_data_hash.rb'
 
 describe Series do
   before(:all) do
+    Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+    Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
      @dh = get_data_hash
      @data_files_path = "#{ENV["DATAFILES_PATH"]}/datafiles/"
-     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
-     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
    end
    
   describe "reporting OBSERVATION COUNTS" do

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -3,7 +3,7 @@ require 'spec_data_hash.rb'
 
 describe Series do
   before(:all) do
-    @dh = get_data_hash
+     @dh = get_data_hash
      @data_files_path = "#{ENV["DATAFILES_PATH"]}/datafiles/"
    end
 

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -5,6 +5,8 @@ describe Series do
   before(:all) do
      @dh = get_data_hash
      @data_files_path = "#{ENV["DATAFILES_PATH"]}/datafiles/"
+     Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' })
+     Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' })
    end
    
   describe "reporting OBSERVATION COUNTS" do

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -3,12 +3,24 @@ require 'spec_data_hash.rb'
 
 describe Series do
   before(:all) do
-    Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
-    Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
-     @dh = get_data_hash
+    @dh = get_data_hash
      @data_files_path = "#{ENV["DATAFILES_PATH"]}/datafiles/"
    end
-   
+
+  before(:each) do
+    Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
+    Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
+    Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
+    Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
+    Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
+    Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
+    Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
+  end
+
   describe "reporting OBSERVATION COUNTS" do
     before(:all) do
       @series_values = Series.create_dummy("monthly_test_series", :month, "2000-05-01", 1, 36)
@@ -335,6 +347,17 @@ describe Series do
   
   describe "DATA POINT dynamics" do    
     before(:all) do
+      Geography.create!({ handle: 'HI', display_name: 'State of Hawaii', display_name_short: 'Hawaii' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'HI') || raise('DID NOT CREATE HI DUDE')
+      Geography.create!({ handle: 'HAW', display_name: 'Hawaii County', display_name_short: 'Big Island' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'HAW') || raise('DID NOT CREATE HAW DUDE')
+      Geography.create!({ handle: 'KAU', display_name: 'Kauai County', display_name_short: 'Garden Isle' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE KAU DUDE')
+      Geography.create!({ handle: 'MAU', display_name: 'Maui County', display_name_short: 'Valley Isle' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'KAU') || raise('DID NOT CREATE MAU DUDE')
+      Geography.create!({ handle: 'HON', display_name: 'C & C of Honolulu', display_name_short: 'Gathering Place' }) rescue nil
+      Geography.find_by(universe: 'UHERO', handle: 'HON') || raise('DID NOT CREATE HON DUDE')
+      Geography.create!({ handle: 'TEST', display_name: 'State of Test', display_name_short: 'Test' }) rescue nil
       @data_hash = "EIFNS@HI.M".tsn.load_from("#{ENV["DATAFILES_PATH"]}/datafiles/ns_update.xls").data
       @data_no_nil = @data_hash.clone
       @data_no_nil.delete_if {|key,value| value.nil?}


### PR DESCRIPTION
This story is about making sure `Series.geography_id` is assigned whenever Series are created. I am reasonably convinced that all Series creation comes through this part of the code that I have modified. Geography is added to the left-side display of the series#show page, with a notice in red if none is linked. All UHERO series currently are linked to their geography.

I have added a `Series.parse_name` method which (arbitrarily) stipulates that the geography part of the series name must contain only alphanumeric and underscore. This should cause no trouble now, and is probably a good constraint to stick to in the future. The only constraint on the prefix is that it not contain whitespace.

## Testing
1. Try creating series through the web gui (`/series/new`). Try putting wrong input in the prefix field. Whitespace at the front and back of the prefix will be trimmed off, but internal whitespace should raise an error.
2. Within a rails console, call `Series.get_or_new()` with a variety of series names. Creation should fail if the geography handle does not exist, or if the frequency is not one of the usual set.