### PR TITLE
Added links to table and froze first column

### DIFF
--- a/app/assets/stylesheets/forecast_snapshots.scss
+++ b/app/assets/stylesheets/forecast_snapshots.scss
@@ -4,20 +4,18 @@
 
 .snapshot-table-title {
   color: #1D667F;
-  font-family: 'Geneva';
+  font-family: 'Geneva', serif;
   font-weight: normal;
   min-width: 100px;
   text-align: center;
 }
 
 .snapshot-table {
-  border-bottom: 3px solid #1D667F;
   border-collapse: collapse;
-  font-family: Arial;
+  font-family: Arial, sans-serif;
 
   tbody {
     th {
-      border-bottom: 3px solid #1D667F;
       color: #1D667F;
       font-size: 15px;
       padding-right: 20px;
@@ -54,8 +52,24 @@
 
 .table-note {
   p {
-    font-family: Arial;
+    font-family: Arial, sans-serif;
     font-size: 15px;
     margin-left: 20px;
+  }
+}
+
+.freeze-header-column {
+  border-bottom: 3px solid #1D667F;
+  overflow-x: scroll;
+  padding-left: 12em;
+
+  .header-col {
+    position: absolute;
+	width: 12em;
+	left: 0;
+    background-color: #FFFFFF;
+    overflow-x: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 }

--- a/app/views/forecast_snapshots/index.html.erb
+++ b/app/views/forecast_snapshots/index.html.erb
@@ -35,7 +35,7 @@
         <td><%= fs.created_at.localtime.strftime("%m/%d/%y") %></td>
         <td><%= fs.updated_at.localtime.strftime("%m/%d/%y") %></td>
         <td>
-          <%= link_to 'Table', forecast_snapshots_path(fs) + '/table' %>
+          <%= link_to 'Table', forecast_snapshot_path(fs) + '/table' %>
         </td>
         <% if current_user.admin_user? %>
            <td><%= link_to 'Edit', edit_forecast_snapshot_path(fs) %></td>

--- a/app/views/forecast_snapshots/index.html.erb
+++ b/app/views/forecast_snapshots/index.html.erb
@@ -34,6 +34,9 @@
         <% end %>
         <td><%= fs.created_at.localtime.strftime("%m/%d/%y") %></td>
         <td><%= fs.updated_at.localtime.strftime("%m/%d/%y") %></td>
+        <td>
+          <%= link_to 'Table', forecast_snapshots_path(fs) + '/table' %>
+        </td>
         <% if current_user.admin_user? %>
            <td><%= link_to 'Edit', edit_forecast_snapshot_path(fs) %></td>
         <% end %>

--- a/app/views/forecast_snapshots/show.html.erb
+++ b/app/views/forecast_snapshots/show.html.erb
@@ -1,5 +1,6 @@
 <p id="notice"><%= notice %></p>
 
+<%= link_to 'Table', forecast_snapshot_path(@forecast_snapshot) + '/table' %> |
 <%= link_to 'Edit', edit_forecast_snapshot_path(@forecast_snapshot) %> |
 <%= link_to 'Back', forecast_snapshots_path %>
 

--- a/app/views/forecast_snapshots/table.html.erb
+++ b/app/views/forecast_snapshots/table.html.erb
@@ -1,15 +1,16 @@
 <p id="notice"><%= notice %></p>
 
+<%= link_to 'Charts', forecast_snapshot_path(@forecast_snapshot) %> |
 <%= link_to 'Edit', edit_forecast_snapshot_path(@forecast_snapshot) %> |
 <%= link_to 'Back', forecast_snapshots_path %>
 
 <h2 class="snapshot-table-title"><%= @forecast_snapshot.name+' ('+@forecast_snapshot.version+')' %></h2>
 <p><%= @forecast_snapshot.created_at.localtime.strftime('%m/%d/%y') %></p>
 
-
+<div class="freeze-header-column">
 <table class="snapshot-table">
   <tr>
-    <th></th>
+    <th class="header-col"> &nbsp; </th>
     <% @all_dates.each do |date| %>
         <th>
           <%= if @all_dates.any? {|s| (s.include? '-04-') || (s.include? '-07-') || (s.include? '-10-')} then
@@ -30,19 +31,25 @@
   </tr>
   <% @forecast_snapshot.new_forecast_tsd.get_all_series.each do |s| %>
     <tr>
-      <td class="series-title"><%= s[:name] + '.' + s[:frequency] %></td>
+      <%
+        mnemonic = s[:name] + '.' + s[:frequency]
+        display_name = @forecast_snapshot.retrieve_name(mnemonic) + ' (' + mnemonic + ')'
+      %>
+      <td class="header-col series-title" title="<%= display_name %>"><%= display_name %></td>
       <% @all_dates.each do |date| %>
         <td class="series-data"><%= s[:data_hash][date].nil? ? '' : number_with_precision(s[:data_hash][date], precision: s[:udaman_series][:decimals], separator: '.', delimiter: ',') %></td>
       <% end %>
     </tr>
     <tr>
-       <td class="change"> &nbsp; % Change</td>
+       <td class="header-col change"> &nbsp; % Change</td>
       <% @all_dates.each do |date| %>
           <td class="change-data"><%= s[:yoy_hash][date].nil? ? '' : number_with_precision(s[:yoy_hash][date], precision: s[:udaman_series][:decimals], separator: '.', delimiter: ',') %></td>
       <% end %>
     </tr>
   <% end %>
 </table>
+</div>
+
 <div class="table-note">
-  <p>Note: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  <p>Note: <%= @forecast_snapshot[:comments].to_s %></p>
 </div>


### PR DESCRIPTION
You should now be able to get from the forecast snapshot chart view to the table view. The first column of the chart is also frozen. The default notes are now the forecast_snapshot comments.