### PR TITLE
Aggregating weekly series (UA-636)

### DIFF
--- a/config/initializers/date_extension.rb
+++ b/config/initializers/date_extension.rb
@@ -119,7 +119,12 @@ class Date
   def days_in_month
     Time.days_in_month(self.month, self.year)
   end
-  
+
+  def delta_days(other_endpt)
+    raise 'delta_days: other endpoint is not a Date' unless other_endpt.class == Date
+    (self - other_endpt).to_i.abs
+  end
+
   def Date.last_7_days
     last_7 = []
     (0..6).each { |index| last_7[index] = (today - index).to_s }

--- a/config/initializers/date_extension.rb
+++ b/config/initializers/date_extension.rb
@@ -102,9 +102,18 @@ class Date
   end
   
   def days_in_period(frequency)
-    return (self.leap? ? 366 : 365) if frequency == "year"
-    return self.days_in_month + (self >> 1).days_in_month + (self >> 2).days_in_month if frequency == "quarter"
-    return self.days_in_month if frequency == "month"
+    case frequency
+      when 'year'
+        self.leap? ? 366 : 365
+      when 'semi'
+        self.semi_d.days_in_period('quarter') + (self.semi_d >> 3).days_in_period('quarter')
+      when 'quarter'
+        self.quarter_d.days_in_month + (self.quarter_d >> 1).days_in_month + (self.quarter_d >> 2).days_in_month
+      when 'month'
+        self.days_in_month
+      else
+        raise "days_in_period: unknown frequency #{frequency}"
+    end
   end
   
   def days_in_month

--- a/config/initializers/date_extension.rb
+++ b/config/initializers/date_extension.rb
@@ -98,7 +98,7 @@ class Date
   end
 
   def semi_d
-    Date.new(self.year, (self.month - 1) / 6)
+    Date.new(self.year, self.month > 6 ? 7 : 1)
   end
   
   def days_in_period(frequency)

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -43,7 +43,7 @@ module SeriesAggregation
     per = { year: { semi: 2, quarter: 4, month: 12, day: 364 },
             semi: { quarter: 2, month: 6, day: 180 },
             quarter: { month: 3, day: 89 } }
-    minimum_data_points = per[frequency] && per[frequency][myfreq]
+    minimum_data_points = per[frequency][myfreq] if per[frequency]
     unless override_prune
       if frequency == :month && myfreq == :day
         grouped_data.delete_if {|key,value| value.count != key.days_in_month}

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -28,7 +28,7 @@ module SeriesAggregation
     orig_series = self
     if myfreq == 'week'
       myfreq = 'day'
-      orig_series = self.fill_week
+      orig_series = fill_weeks
     end
     agg_date_method = frequency.to_s + '_d' ## see date_extension.rb
 
@@ -50,7 +50,7 @@ module SeriesAggregation
     grouped_data
   end
 
-  def fill_week
+  def fill_weeks
     raise AggregationException.new, 'original series is not weekly' unless self.frequency == 'week'
     dailyseries = {}
     self.data.keys.sort.each do |date|

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -5,7 +5,7 @@ module SeriesAggregation
     new_series
   end
   
-  def aggregate_data_by(frequency,operation, override_prune = false)
+  def aggregate_data_by(frequency, operation, override_prune = false)
     validate_aggregation(frequency)
     
     grouped_data = group_data_by frequency, override_prune
@@ -16,39 +16,40 @@ module SeriesAggregation
     aggregated_data
   end
   
-  def aggregate_by(frequency,operation, override_prune = false)
+  def aggregate_by(frequency, operation, override_prune = false)
     aggregate(frequency, operation, override_prune)
   end
   
   # Only returns complete groups
   def group_data_by(frequency, override_prune = false)
     validate_aggregation(frequency)
-    
-    aggregated_data = Hash.new
-    frequency_method = frequency.to_s + '_d'
+
+    grouped_data = {}
+    agg_date_method = frequency.to_s + '_d' ## see date_extension.rb
     
     self.data.keys.each do |date|
       next if self.at(date).nil?
-      aggregated_data[date.send(frequency_method)] ||= AggregatingArray.new
-      aggregated_data[date.send(frequency_method)].push self.at(date)
+      agg_date = date.send(agg_date_method)
+      grouped_data[agg_date] ||= AggregatingArray.new
+      grouped_data[agg_date].push self.at(date)
     end
 
     freq = self.frequency.to_s
 
-    aggregated_data.delete_if {|_,value| value.count != 6} if frequency == :semi and freq == 'month'
-    aggregated_data.delete_if {|_,value| value.count != 3} if (frequency == :quarter and freq == 'month') and override_prune == false
-    aggregated_data.delete_if {|_,value| value.count != 12} if frequency == :year and freq == 'month'
-    aggregated_data.delete_if {|_,value| value.count != 4} if frequency == :year and freq == 'quarter'
-    aggregated_data.delete_if {|_,value| value.count != 2} if frequency == :semi and freq == 'quarter'
-    aggregated_data.delete_if {|_,value| value.count != 2} if frequency == :year and freq == 'semi'
-    aggregated_data.delete_if {|key,value| value.count != key.days_in_month} if frequency == :month and freq == 'day'
-    aggregated_data
+    grouped_data.delete_if {|_,value| value.count != 6} if frequency == :semi and freq == 'month'
+    grouped_data.delete_if {|_,value| value.count != 3} if (frequency == :quarter and freq == 'month') and override_prune == false
+    grouped_data.delete_if {|_,value| value.count != 12} if frequency == :year and freq == 'month'
+    grouped_data.delete_if {|_,value| value.count != 4} if frequency == :year and freq == 'quarter'
+    grouped_data.delete_if {|_,value| value.count != 2} if frequency == :semi and freq == 'quarter'
+    grouped_data.delete_if {|_,value| value.count != 2} if frequency == :year and freq == 'semi'
+    grouped_data.delete_if {|_,value| value.count != 7} if frequency == :week and freq == 'day'
+    grouped_data.delete_if {|key,value| value.count != key.days_in_month} if frequency == :month and freq == 'day'
+    grouped_data
   end
   
   def validate_aggregation(frequency)
     freq_order = %w[year semi quarter month week day]
-    raise AggregationException.new unless freq_order.include? frequency
-    raise AggregationException.new unless %w[year semi quarter month day].include? self.frequency
+    raise AggregationException.new unless freq_order.include?(frequency) && freq_order.include?(self.frequency)
     raise AggregationException.new if freq_order.index(frequency.to_s) >= freq_order.index(self.frequency)
     #raise AggregationException.new if freq == 'year'
     #raise AggregationException.new if freq == 'semi'  and (frequency == :month or frequency == :quarter or frequency == :semi or frequency == :week or frequency == :day)

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -5,10 +5,6 @@ module SeriesAggregation
     new_series
   end
   
-  # def aggregate_to(frequency, operation, series_to_store_name)
-  #   series_to_store_name.ts= aggregate frequency, operation
-  # end
-  
   def aggregate_data_by(frequency,operation, override_prune = false)
     validate_aggregation(frequency)
     
@@ -22,7 +18,6 @@ module SeriesAggregation
   
   def aggregate_by(frequency,operation, override_prune = false)
     aggregate(frequency, operation, override_prune)
-    #Series.new(:data=>aggregate_data_by(frequency, operation, override_prune), :frequency=>frequency)
   end
   
   # Only returns complete groups
@@ -33,18 +28,12 @@ module SeriesAggregation
     frequency_method = frequency.to_s + '_d'
     
     self.data.keys.each do |date|
-      #puts "#{date_string}: #{self.at date_string}"
       next if self.at(date).nil?
       aggregated_data[date.send(frequency_method)] ||= AggregatingArray.new
       aggregated_data[date.send(frequency_method)].push self.at(date)
     end
-    #puts frequency
-    #puts self.frequency
-    #puts override_prune
-    # Prune out any incomplete aggregated groups (except days, since it's complicated to match month to day count)
-    #can probably take out this override pruning nonsense since this function doesn't work anyway and should be some kind of interpolation
-    
-      freq = self.frequency.to_s
+
+    freq = self.frequency.to_s
 
     aggregated_data.delete_if {|_,value| value.count != 6} if frequency == :semi and freq == 'month'
     aggregated_data.delete_if {|_,value| value.count != 3} if (frequency == :quarter and freq == 'month') and override_prune == false
@@ -53,25 +42,19 @@ module SeriesAggregation
     aggregated_data.delete_if {|_,value| value.count != 2} if frequency == :semi and freq == 'quarter'
     aggregated_data.delete_if {|_,value| value.count != 2} if frequency == :year and freq == 'semi'
     aggregated_data.delete_if {|key,value| value.count != key.days_in_month} if frequency == :month and freq == 'day'
-    #puts key+" "+value.count.to_s + " " + Date.parse(key).days_in_month.to_s;
-    #month check for days is more complicated because need to check for number of days in each month
-
     aggregated_data
   end
   
   def validate_aggregation(frequency)
-    # The following represent invalid aggregation transitions
-    # puts self.name
-    # puts "self:#{self.frequency}:#{self.frequency.class}"
-    # puts "frequency:#{frequency}:#{frequency.class}"
-
-    freq = self.frequency.to_s
-    raise AggregationException.new if %w(year semi quarter month day).index(freq).nil?
-    raise AggregationException.new if freq == 'year'
-    raise AggregationException.new if freq == 'semi'  and (frequency == :month or frequency == :quarter or frequency == :semi or frequency == :week or frequency == :day)
-    raise AggregationException.new if freq == 'quarter' and (frequency == :month or frequency == :quarter or frequency == :week or frequency == :day)
-    raise AggregationException.new if freq == 'month' and (frequency == :month or frequency == :week or frequency == :day)
-    raise AggregationException.new if freq == 'week' and (frequency == :day or frequency == :week)
-    raise AggregationException.new if freq == 'day' and frequency == :day
+    freq_order = %w[year semi quarter month week day]
+    raise AggregationException.new unless freq_order.include? frequency
+    raise AggregationException.new unless %w[year semi quarter month day].include? self.frequency
+    raise AggregationException.new if freq_order.index(frequency.to_s) >= freq_order.index(self.frequency)
+    #raise AggregationException.new if freq == 'year'
+    #raise AggregationException.new if freq == 'semi'  and (frequency == :month or frequency == :quarter or frequency == :semi or frequency == :week or frequency == :day)
+    #raise AggregationException.new if freq == 'quarter' and (frequency == :month or frequency == :quarter or frequency == :week or frequency == :day)
+    #raise AggregationException.new if freq == 'month' and (frequency == :month or frequency == :week or frequency == :day)
+    #raise AggregationException.new if freq == 'week' and (frequency == :day or frequency == :week)
+    #raise AggregationException.new if freq == 'day' and frequency == :day
   end
 end

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -41,12 +41,12 @@ module SeriesAggregation
     end
 
     unless override_prune
-      per = { year: { semi: 2, quarter: 4, month: 12, day: 365 },
-              semi: { quarter: 2, month: 6, day: 181 },
-              quarter: { month: 3, day: 90 } }
+      per = { year: { semi: 2, quarter: 4, month: 12 },
+              semi: { quarter: 2, month: 6 },
+              quarter: { month: 3 } }
       minimum_data_points = per[frequency][myfreq] if per[frequency]
-      if frequency == :month && myfreq == :day
-        grouped_data.delete_if {|key,value| value.count != key.days_in_month}
+      if myfreq == :day
+        grouped_data.delete_if {|key,value| value.count != key.days_in_period(frequency.to_s) }
       elsif minimum_data_points
         grouped_data.delete_if {|_,value| value.count < minimum_data_points }
       end

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -57,11 +57,11 @@ module SeriesAggregation
   def fill_weeks
     raise AggregationException.new, 'original series is not weekly' unless self.frequency == 'week'
     dailyseries = {}
-    self.data.keys.sort.each do |date|
-      ## Following is 8 rather than 6 to "cover over" tiny gaps of one day here and there between weeks
-      ## (caused in some cases by people recording data observations on the day before a holiday, because
-      ## they won't be at work the next day. Really.)
-      (0..8).each {|offset| dailyseries[date + offset] = self.data[date] }
+    weekly_keys = self.data.keys.sort
+    while date = weekly_keys.shift ## beware: this is an assignment, not a comparison.
+      delta = weekly_keys.empty? ? 99 : date.delta_days(weekly_keys[0])
+      len = delta > 10 ? 6 : delta - 1
+      (0..len).each {|offset| dailyseries[date + offset] = self.data[date] }
     end
     Series.new_transformation("Extrapolated from weekly series #{self.name}", dailyseries, :day)
   end

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -40,11 +40,11 @@ module SeriesAggregation
       grouped_data[agg_date].push orig_series.at(date)
     end
 
-    per = { year: { semi: 2, quarter: 4, month: 12, day: 364 },
-            semi: { quarter: 2, month: 6, day: 180 },
-            quarter: { month: 3, day: 89 } }
-    minimum_data_points = per[frequency][myfreq] if per[frequency]
     unless override_prune
+      per = { year: { semi: 2, quarter: 4, month: 12, day: 365 },
+              semi: { quarter: 2, month: 6, day: 181 },
+              quarter: { month: 3, day: 90 } }
+      minimum_data_points = per[frequency][myfreq] if per[frequency]
       if frequency == :month && myfreq == :day
         grouped_data.delete_if {|key,value| value.count != key.days_in_month}
       elsif minimum_data_points

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -58,6 +58,9 @@ module SeriesAggregation
     raise AggregationException.new, 'original series is not weekly' unless self.frequency == 'week'
     dailyseries = {}
     self.data.keys.sort.each do |date|
+      ## Following is 8 rather than 6 to "cover over" tiny gaps of one day here and there between weeks
+      ## (caused in some cases by people recording data observations on the day before a holiday, because
+      ## they won't be at work the next day. Really.)
       (0..8).each {|offset| dailyseries[date + offset] = self.data[date] }
     end
     Series.new_transformation("Extrapolated from weekly series #{self.name}", dailyseries, :day)

--- a/lib/series_aggregation.rb
+++ b/lib/series_aggregation.rb
@@ -58,7 +58,7 @@ module SeriesAggregation
     raise AggregationException.new, 'original series is not weekly' unless self.frequency == 'week'
     dailyseries = {}
     self.data.keys.sort.each do |date|
-      (0..6).each {|offset| dailyseries[date + offset] = self.data[date] }
+      (0..8).each {|offset| dailyseries[date + offset] = self.data[date] }
     end
     Series.new_transformation("Extrapolated from weekly series #{self.name}", dailyseries, :day)
   end


### PR DESCRIPTION
Note that I've eliminated a bunch of very wordy, hard-to-read code with more compact and easier to understand code (imho). Also note that I have expanded the use of the `override_prune` flag so that it can apply to any aggregation, not just the one use-case that it used to apply to. I'm guessing that there are no cases in the wild of it being set to true except where needed, so this should not cause a problem, and its new global availability may be useful in the future.

## Testing
There is now one non-restricted weekly series in production, `RMORT@US.W`. In a rails console, you can call the aggregate method on it like so:
```
> "RMORT@US.W".ts.data  ## see the original series
> "RMORT@US.W".ts.aggregate(:month, :average).data
> "RMORT@US.W".ts.aggregate(:quarter :average).data
```
You'll see that the data begin 02 April 1971, through first week of June 2017. That's 45 full years plus a little on each end. April 1971 will get pruned when doing `:month`, and 1971Q2 when doing `:quarter`, because 01 April is missing ("aggressive pruning" :=)
This particular series has observations that are obviously entered by hand by people on work days, because there are many, many cases where the normal day of recording falls on a holiday, and the person responsible simply took the observation the last day before the holiday. This results in a gap of one day, which will cause those months to be pruned. There are so many of these throughout this series that I felt it was wrong to allow so many months to be pruned off, so the weekly fill algorithm fills out 8 days from each weekly observation (rather than the normal 6), causing a slight overlap with the following week. These extra data points will be properly overwritten when the following observation is recorded as expected, but they will, I think reasonably, extend the previous week's value to fill these gaps when they occur.