### PR TITLE
NA Handling with BEA API (UA-637)

### DIFF
--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -49,9 +49,12 @@ class DataHtmlParser
     @doc = self.download
     new_data = {}
     bea_data = JSON.parse self.content
-    bea_data['BEAAPI']['Results']['Data'].each do |d| 
-      time_period = d['TimePeriod']
-      new_data[ get_date(time_period[0..3], time_period[4..-1]) ] = d['DataValue'].to_f if d['DataValue'].is_numeric?
+    bea_data['BEAAPI']['Results']['Data'].each do |data_point|
+      time_period = data_point['TimePeriod']
+      value = data_point['DataValue']
+      if value && value.is_numeric?
+        new_data[ get_date(time_period[0..3], time_period[4..-1]) ] = value.to_f
+      end
     end
     new_data
   end


### PR DESCRIPTION
Here's a fix for the reported nil pointer bug. Not sure if some further work to make "NA handling work properly" is needed? Or if it really was just fixing this bug.

To test, try in rails console, the examples given in bug report: `Series.load_from_bea('A', 'RegionalProduct', Component: 'GDP_SAN', IndustryId:3, GeoFips: 15000, Year: 'ALL')`, which should work in any case, versus `Series.load_from_bea('A', 'RegionalProduct', Component: 'GDP_SAN', IndustryId:4, GeoFips: 15000, Year: 'ALL')`, which fails in master but works in branch.