### PR TITLE
NTA load: set Series.dataPortalName to Category.name (UA-754)

### DIFF
--- a/app/models/nta_upload.rb
+++ b/app/models/nta_upload.rb
@@ -215,6 +215,7 @@ class NtaUpload < ActiveRecord::Base
       raise("load_series_csv: no measurement for #{cat.meta}") unless measurement
       prefix = measurement.prefix
       indicator_name = cat.meta.sub(/^NTA_/,'')
+      indicator_title = cat.name
 
       CSV.foreach(series_path, {col_sep: "\t", headers: true, return_headers: false}) do |row|
         row_data = {}
@@ -236,7 +237,7 @@ class NtaUpload < ActiveRecord::Base
                              Series.create(
                                universe: 'NTA',
                                name: series_name,
-                               dataPortalName: '%s (%s)' % [ row_data['name'], indicator_name ],
+                               dataPortalName: indicator_title,
                                frequency: 'year',
                                geography_id: geo_id,  #### Updated for Region/Income Group series below in post proc
                                unit_id: measurement.unit_id,


### PR DESCRIPTION
## Testing
Run an NTA load in testing rails console with something like this: `NtaUpload.find(:id).full_load`
for some `nta_uploads.id` that you already have in the database. This will wipe all NTA data first, then start reloading. After a while, you can try something like the following to see that `dataPortalName` is being set correctly. You should see the `created_at` column tracking the present time, and number of series increasing.
```
select created_at, name, dataPortalName
from series
where universe = 'NTA'
order by 1 desc
```