### PR TITLE
Bug in date conversion (UA-769)

### DIFF
--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -106,7 +106,7 @@ class DataHtmlParser
     return Date.new(year_string.to_i, other_string[1..2].to_i) unless %w(M01 M02 M03 M04 M05 M06 M07 M08 M09 M10 M11 M12).index(other_string).nil?
     return Date.new(year_string.to_i) if other_string == 'S01'
     return Date.new(year_string.to_i, 7) if other_string == 'S02'
-    return Date.new(year_string) unless %w(Q1 Q01).index(other_string).nil?
+    return Date.new(year_string.to_i) unless %w(Q1 Q01).index(other_string).nil?
     return Date.new(year_string.to_i, 4) unless %w(Q2 Q02).index(other_string).nil?
     return Date.new(year_string.to_i, 7) unless %w(Q3 Q03).index(other_string).nil?
     return Date.new(year_string.to_i, 10) unless %w(Q4 Q04).index(other_string).nil?


### PR DESCRIPTION
Jimmy reported RonR error when trying to add the following data source to series 159108 (YS@HI.Q):

`Series.load_from_bea('Q', 'RegionalProduct', Component: 'GDP_SQN', IndustryId:1, GeoFips: 15000, Year: 'ALL')`

Fix seemed straightforward, and probably just trying to perform this action should suffice for testing.