### PR TITLE
Fix links which should not be display:block (UA-703)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -118,7 +118,8 @@ form button,
 table#search_results td {border:none;}
 
 /* anchor tags inside table cells will be highlighted and clickable across the whole width of the <td> cell */
-td a:link { display: block; text-decoration: none; }
+td a:link { text-decoration: none; }
+td.linkselect a:link { display: block }
 
 /* No underlining for links in top menu */
 div#top-level-nav a:link { text-decoration: none; }

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field">
     <%= f.label :name %><br>
-    <%= f.text_field :name %>
+    <%= f.text_field :name, :size => 100 %>
     Hidden?
     <%= f.check_box :hidden %>
   </div>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field">
     <%= f.label :name %><br>
-    <%= f.text_field :name, :size => 100 %>
+    <%= f.text_field :name, :size => 80 %>
     Hidden?
     <%= f.check_box :hidden %>
   </div>

--- a/app/views/data_lists/index.html.erb
+++ b/app/views/data_lists/index.html.erb
@@ -14,9 +14,8 @@
 
 <% @data_lists.order(:name).each do |data_list| %>
   <tr>
-    <td><%= link_to data_list.name, :action => 'super_table', :id => data_list %></td>
+    <td class="linkselect"><%= link_to data_list.name, :action => 'super_table', :id => data_list %></td>
     <td><%= data_list.measurements.count %></td>
-    <td><%= link_to 'FlexTable', :action => 'super_table', :id => data_list %></td>
     <% if current_user.admin_user? || data_list.owned_by == current_user.id %>
       <td><%= link_to 'Edit', edit_data_list_path(data_list) %></td>
     <% end %>

--- a/app/views/downloads/index.html.erb
+++ b/app/views/downloads/index.html.erb
@@ -35,7 +35,7 @@
 					<% if download.handle.nil? %>
 					<td><strong style="color:#DDD"><%= filename %></strong></td>
 					<% else %>
-					<td><%= link_to download.handle , {:action => 'show', :id => download.id}, target: '_blank' %></td>
+					<td class="linkselect"><%= link_to download.handle , {:action => 'show', :id => download.id}, target: '_blank' %></td>
 					<% end %>
 					<td><%= link_to "download" , {:action => 'download', :id => download.id}%></td>
 					<td><%= link_to "edit" , {:action => 'edit', :id => download.id} %></td>

--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -16,7 +16,7 @@
   <tbody>
     <% @exports.each do |export| %>
       <tr>
-        <td><%= link_to export.name, export %></td>
+        <td class="linkselect"><%= link_to export.name, export %></td>
         <td><%= export.series.count %></td>
         <td><%= link_to 'CSV', action: 'show', id: export, format: 'csv' %></td>
         <td><%= link_to 'Table', action: 'show_table', id: export %></td>

--- a/app/views/forecast_snapshots/_form.html.erb
+++ b/app/views/forecast_snapshots/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field">
     <%= f.label :name %><br>
-    <%= f.text_field :name %>
+    <%= f.text_field :name, :size => 80 %>
     Published?
     <%= f.check_box :published %>
   </div>

--- a/app/views/forecast_snapshots/index.html.erb
+++ b/app/views/forecast_snapshots/index.html.erb
@@ -26,7 +26,7 @@
   <tbody>
     <% @forecast_snapshots.each do |fs| %>
       <tr>
-        <td><%= link_to fs.name, fs %></td>
+        <td class="linkselect"><%= link_to fs.name, fs %></td>
         <td align="center"><%= fs.version %></td>
         <td><%= fs.comments %></td>
         <% if current_user.internal_user? %>

--- a/app/views/geographies/index.html.erb
+++ b/app/views/geographies/index.html.erb
@@ -18,7 +18,7 @@
       <tr>
         <td><%= geography.fips %></td>
         <td><%= geography.handle %></td>
-        <td><%= link_to geography.display_name, edit_geography_path(geography) %></td>
+        <td class="linkselect"><%= link_to geography.display_name, edit_geography_path(geography) %></td>
         <td><%= geography.display_name_short %></td>
         <td><%= link_to 'Destroy', geography, method: :delete, data: { confirm: "Destroy #{geography.display_name}: Are you sure??" } %></td>
       </tr>

--- a/app/views/measurements/index.html.erb
+++ b/app/views/measurements/index.html.erb
@@ -28,7 +28,7 @@
     <% @measurements.each do |measurement| %>
       <tr>
         <td><%= measurement.prefix %></td>
-        <td><%= link_to measurement.data_portal_name, measurement %></td>
+        <td class="linkselect"><%= link_to measurement.data_portal_name, measurement %></td>
         <td><%= measurement.units_label %></td>
         <td><%= measurement.units_label_short %></td>
         <td><%= measurement.percent %></td>

--- a/app/views/source_details/index.html.erb
+++ b/app/views/source_details/index.html.erb
@@ -13,7 +13,7 @@
   <tbody>
     <% @source_details.each do |source_detail| %>
       <tr>
-        <td><%= link_to source_detail.description, edit_source_detail_path(source_detail) %></td>
+        <td class="linkselect"><%= link_to source_detail.description, edit_source_detail_path(source_detail) %></td>
         <td><%= link_to 'Destroy', source_detail, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/sources/index.html.erb
+++ b/app/views/sources/index.html.erb
@@ -19,7 +19,7 @@
   <tbody>
     <% @sources.each do |source| %>
       <tr>
-        <td><%= link_to source.description, edit_source_path(source) %></td>
+        <td class="linkselect"><%= link_to source.description, edit_source_path(source) %></td>
         <td><%= source.link %></td>
         <td><%= link_to 'Destroy', source, method: :delete, data: { confirm: "Destroy #{source.description}: Are you sure??" } %></td>
       </tr>

--- a/app/views/units/_form.html.erb
+++ b/app/views/units/_form.html.erb
@@ -17,7 +17,7 @@
   </div>
   <div class="field">
     <%= f.label :long_label %><br>
-    <%= f.text_field :long_label %>
+    <%= f.text_field :long_label, :size => 80 %>
   </div>
   <div class="actions">
     <%= f.submit %>

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -18,7 +18,7 @@
     <% @units.each do |unit| %>
       <tr>
         <td><%= unit.short_label %></td>
-        <td><%= link_to unit.long_label, edit_unit_path(unit) %></td>
+        <td class="linkselect"><%= link_to unit.long_label, edit_unit_path(unit) %></td>
         <td><%= link_to 'Destroy', unit, method: :delete, data: { confirm: "Destroy unit #{unit.to_s}.\n#{num_affected(unit)}. Are you sure??" } %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
The main point of this story was to fix (restore to former layout) the formatting of the data source links (load/clear/delete/edit) on the main series page. A good one with a lot of sources to check on is `/series/152240`.

This was broken by changes to allow the mouse-over highlighting on the index pages of several top-level model objects like `data_lists`, `exports`, `units`, `measurements`, `sources`, etc. Check that those index pages have maintained their recent look and feel.

A few other minor adjustments of text field size on edit forms are included just because.