### PR TITLE
Finish removing unitsLabel/Short from udaman/UHERO code (UA-829)

### DIFF
--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -7,8 +7,6 @@ class MeasurementsController < ApplicationController
 
   ALL_PROPAGATE_FIELDS = [
       ['Data portal name', :data_portal_name],
-      ['Units label', :units_label],
-      ['Units label, short', :units_label_short],
       ['Units', :unit_id],
       ['Source', :source_id],
       ['Source detail', :source_detail_id],
@@ -115,9 +113,7 @@ class MeasurementsController < ApplicationController
   private
     def translate(name)
       # Translate column names from Measurement table form to Series table form
-      trans_hash = {'data_portal_name' => 'dataPortalName',
-                    'units_label' => 'unitsLabel',
-                    'units_label_short' => 'unitsLabelShort'}
+      trans_hash = {'data_portal_name' => 'dataPortalName'}
       trans_hash[name] || name
     end
 
@@ -128,8 +124,8 @@ class MeasurementsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def measurement_params
-      params.require(:measurement).permit(:prefix, :data_portal_name, :table_prefix, :table_postfix, :units_label,
-                                          :units_label_short, :unit_id, :percent, :real, :notes,
+      params.require(:measurement).permit(:prefix, :data_portal_name, :table_prefix, :table_postfix,
+                                          :unit_id, :percent, :real, :notes,
                                           :restricted, :unrestricted, :series_id, :decimals,
                                           :seasonally_adjusted, :seasonal_adjustment, :frequency_transform,
                                           :source_detail_id, :source_id, :source_link,

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -3,7 +3,7 @@ class UnitsController < ApplicationController
 
   # GET /units
   def index
-    @units = Unit.order(:short_label, :long_label).all
+    @units = Unit.where(universe: 'UHERO').order(:short_label, :long_label).all
   end
 
   # GET /units/1

--- a/app/models/forecast_snapshot.rb
+++ b/app/models/forecast_snapshot.rb
@@ -27,8 +27,7 @@ class ForecastSnapshot < ActiveRecord::Base
   def retrieve_units(prefix)
     m = Measurement.find_by(prefix: prefix.chomp('NS'))
     return 'Values' if m.nil?
-    return m.unit.short_label if !m.unit.nil?
-    m.units_label_short.blank? ? 'Values' : m.units_label_short
+    m.unit ? m.unit.short_label : 'Values'
   end
 
   # Get series ID for each series

--- a/app/views/measurements/index.html.erb
+++ b/app/views/measurements/index.html.erb
@@ -15,8 +15,7 @@
     <tr>
       <th>Prefix</th>
       <th>Data portal name</th>
-      <th>Units label</th>
-      <th>Units label short</th>
+      <th>Units</th>
       <th>Percent</th>
       <th>Real</th>
       <th>Notes</th>
@@ -29,8 +28,7 @@
       <tr>
         <td><%= measurement.prefix %></td>
         <td class="linkselect"><%= link_to measurement.data_portal_name, measurement %></td>
-        <td><%= measurement.units_label %></td>
-        <td><%= measurement.units_label_short %></td>
+        <td><%= measurement.unit.to_s %></td>
         <td><%= measurement.percent %></td>
         <td><%= measurement.real %></td>
         <td><%= measurement.notes %></td>

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -43,11 +43,11 @@ task :reset_measurements => :environment do
   ActiveRecord::Base.connection.execute('DELETE FROM data_list_measurements;')
   ActiveRecord::Base.connection.execute('ALTER TABLE data_list_measurements AUTO_INCREMENT = 1;')
   ActiveRecord::Base.connection.execute(%Q|INSERT INTO
-measurements (prefix, data_portal_name, units_label, units_label_short, percent, `real`, created_at, updated_at)
+measurements (prefix, data_portal_name, unit_id, percent, `real`, created_at, updated_at)
 (SELECT
   TRIM(TRAILING '&NS' FROM TRIM(TRAILING 'NS' FROM UPPER(LEFT(series.name, LOCATE('@', series.name) - 1)))) AS prefix,
   MAX(dataPortalName) AS data_portal_name,
-  MAX(unitsLabel) AS units_label, MAX(unitsLabelShort) AS units_label_short, MAX(percent) AS percent,
+  MAX(unit_id) AS unit_id, MAX(percent) AS percent,
   MAX(series.real) AS `real`, NOW(), NOW()
 FROM series GROUP BY
   TRIM(TRAILING '&NS' FROM TRIM(TRAILING 'NS' FROM UPPER(LEFT(series.name, LOCATE('@', series.name) - 1))))

--- a/spec/views/measurements/index.html.erb_spec.rb
+++ b/spec/views/measurements/index.html.erb_spec.rb
@@ -2,11 +2,17 @@ require 'rails_helper'
 
 RSpec.describe 'measurements/index', :type => :view do
   before(:each) do
+    assign(:units, [
+        Unit.create!(
+                long_label: 'Thousands of Widgets',
+                short_label: 'WidgThous'
+        )
+    ])
     assign(:measurements, [
       Measurement.create!(
         :prefix => 'Prefix',
         :data_portal_name => 'Data Portal Name',
-        :unit_id => 42,
+        :unit_id => Unit.first.id,
         :percent => false,
         :real => true,
         :notes => 'MyText'
@@ -14,7 +20,7 @@ RSpec.describe 'measurements/index', :type => :view do
       Measurement.create!(
         :prefix => 'Prefix',
         :data_portal_name => 'Data Portal Name',
-        :unit_id => 42,
+        :unit_id => Unit.first.id,
         :percent => false,
         :real => true,
         :notes => 'MyText'
@@ -26,7 +32,7 @@ RSpec.describe 'measurements/index', :type => :view do
     render
     assert_select 'tr>td', :text => 'Prefix'.to_s, :count => 2
     assert_select 'tr>td', :text => 'Data Portal Name'.to_s, :count => 2
-    assert_select 'tr>td', :text => 42.to_s, :count => 2
+    assert_select 'tr>td', :text => Unit.first.id.to_s, :count => 2
     assert_select 'tr>td', :text => false.to_s, :count => 2
     assert_select 'tr>td', :text => true.to_s, :count => 2
     assert_select 'tr>td', :text => 'MyText'.to_s, :count => 2

--- a/spec/views/measurements/index.html.erb_spec.rb
+++ b/spec/views/measurements/index.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'measurements/index', :type => :view do
     render
     assert_select 'tr>td', :text => 'Prefix'.to_s, :count => 2
     assert_select 'tr>td', :text => 'Data Portal Name'.to_s, :count => 2
-    assert_select 'tr>td', :text => Unit.first.id.to_s, :count => 2
+    assert_select 'tr>td', :text => Unit.first.to_s, :count => 2
     assert_select 'tr>td', :text => false.to_s, :count => 2
     assert_select 'tr>td', :text => true.to_s, :count => 2
     assert_select 'tr>td', :text => 'MyText'.to_s, :count => 2

--- a/spec/views/measurements/index.html.erb_spec.rb
+++ b/spec/views/measurements/index.html.erb_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe 'measurements/index', :type => :view do
       Measurement.create!(
         :prefix => 'Prefix',
         :data_portal_name => 'Data Portal Name',
-        :units_label => 'Units Label',
-        :units_label_short => 'Units Label Short',
+        :unit_id => 42,
         :percent => false,
         :real => true,
         :notes => 'MyText'
@@ -15,8 +14,7 @@ RSpec.describe 'measurements/index', :type => :view do
       Measurement.create!(
         :prefix => 'Prefix',
         :data_portal_name => 'Data Portal Name',
-        :units_label => 'Units Label',
-        :units_label_short => 'Units Label Short',
+        :unit_id => 42,
         :percent => false,
         :real => true,
         :notes => 'MyText'
@@ -28,8 +26,7 @@ RSpec.describe 'measurements/index', :type => :view do
     render
     assert_select 'tr>td', :text => 'Prefix'.to_s, :count => 2
     assert_select 'tr>td', :text => 'Data Portal Name'.to_s, :count => 2
-    assert_select 'tr>td', :text => 'Units Label'.to_s, :count => 2
-    assert_select 'tr>td', :text => 'Units Label Short'.to_s, :count => 2
+    assert_select 'tr>td', :text => 42.to_s, :count => 2
     assert_select 'tr>td', :text => false.to_s, :count => 2
     assert_select 'tr>td', :text => true.to_s, :count => 2
     assert_select 'tr>td', :text => 'MyText'.to_s, :count => 2


### PR DESCRIPTION
Need to remove these fields from the database and wherever else they are referred to, to finally finish them off for good. They are still being set for DBEDT, and apparently still used in that portal.

Included is a restriction on the `Units` index page to include only UHERO units.

## Testing
* Check Measurements index page to see that units are displayed in the list appropriately.
* Create a new measurement
* Edit a measurement and change units
* Propagate units to member series
* Open a rails console and do `ForecastSnapshot.new.retrieve_units('VSDM')`, or pass some other measurement prefix that has units set, and you should get the unit's `short_label`. If you pass a prefix which has no units set, "Values" will be returned.
  