### PR TITLE
Changes to quarantine to be reflected immediately in public dp (UA-798)

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -96,19 +96,23 @@ class SeriesController < ApplicationController
 
   def add_to_quarantine
     @series = Series.find_by id: params[:id]
-    @series.update! quarantined: true
+    if @series
+      @series.add_to_quarantine
+    end
     redirect_to action: :show, id: params[:id]
   end
 
   def remove_from_quarantine
     next_action = params[:next_action] || :show
     @series = Series.find_by id: params[:id]
-    @series.update! quarantined: false
+    if @series
+      @series.remove_from_quarantine
+    end
     redirect_to action: next_action, id: params[:id]
   end
 
   def empty_quarantine
-    Series.where(universe: 'UHERO').update_all quarantined: false
+    Series.empty_quarantine
     redirect_to action: :quarantine
   end
 

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -103,12 +103,13 @@ class SeriesController < ApplicationController
   end
 
   def remove_from_quarantine
-    next_action = params[:next_action] || :show
+    dest = { action: params[:next_action] || :show }
+    dest[:id] = params[:id] if dest[:action] == :show
     @series = Series.find_by id: params[:id]
     if @series
       @series.remove_from_quarantine
     end
-    redirect_to action: next_action, id: params[:id]
+    redirect_to dest
   end
 
   def empty_quarantine

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -142,12 +142,17 @@ class DataPoint < ActiveRecord::Base
 
   def DataPoint.update_public_data_points(universe = 'UHERO', series = nil)
     if series && series.quarantined?
-      logger.info { "Did not update public data points because series #{series.name} is quarantined" }
-      return false
+      quarantine_query = <<~SQL
+         delete from public_data_points where series_id = ?
+      SQL
+      stmt = ActiveRecord::Base.connection.raw_connection.prepare(quarantine_query)
+      stmt.execute(series.id)
+      stmt.close
+      return true
     end
     t = Time.now
     insert_type = universe == 'NTA' ? 'replace' : 'insert'
-    update_query = %Q(
+    update_query = <<~SQL
       update public_data_points p
         join data_points d on d.series_id = p.series_id and d.date = p.date and d.current
         join series s on s.id = d.series_id
@@ -158,8 +163,8 @@ class DataPoint < ActiveRecord::Base
       and not s.quarantined
       and (d.updated_at is null or d.updated_at > p.updated_at)
       #{' and s.id = ? ' if series} ;
-    )
-    insert_query = %Q(
+    SQL
+    insert_query = <<~SQL
       #{insert_type} into public_data_points (universe, series_id, date, value, pseudo_history, created_at, updated_at)
       select d.universe, d.series_id, d.date, d.value, d.pseudo_history, d.created_at, coalesce(d.updated_at, d.created_at)
       from data_points d
@@ -170,8 +175,8 @@ class DataPoint < ActiveRecord::Base
       and d.current
       and p.created_at is null  /* dp doesn't exist in public_data_points yet */
       #{' and s.id = ? ' if series} ;
-    )
-    delete_query = %Q(
+    SQL
+    delete_query = <<~SQL
       delete p
       from public_data_points p
         join series s on s.id = p.series_id
@@ -180,7 +185,7 @@ class DataPoint < ActiveRecord::Base
       and not s.quarantined
       and d.created_at is null  /* dp no longer exists in data_points */
       #{' and s.id = ? ' if series} ;
-    )
+    SQL
     ActiveRecord::Base.transaction do
       stmt = ActiveRecord::Base.connection.raw_connection.prepare(update_query)
       series ? stmt.execute(universe, series.id) : stmt.execute(universe)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -364,7 +364,7 @@ class Series < ActiveRecord::Base
   end
 
   def Series.empty_quarantine
-    Series.where(universe: 'UHERO').update_all quarantined: false
+    Series.where(universe: 'UHERO', quarantined: true).update_all quarantined: false
     DataPoint.update_public_data_points('UHERO')
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -365,6 +365,7 @@ class Series < ActiveRecord::Base
 
   def Series.empty_quarantine
     Series.where(universe: 'UHERO').update_all quarantined: false
+    DataPoint.update_public_data_points('UHERO')
   end
 
   def update_data_hash

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -353,6 +353,18 @@ class Series < ActiveRecord::Base
     []
   end
 
+  def add_to_quarantine
+    self.update! quarantined: true
+  end
+
+  def remove_from_quarantine
+    self.update! quarantined: false
+  end
+
+  def Series.empty_quarantine
+    Series.where(universe: 'UHERO').update_all quarantined: false
+  end
+
   def update_data_hash
     data_hash = {}
     data_points.each do |dp|

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -355,10 +355,12 @@ class Series < ActiveRecord::Base
 
   def add_to_quarantine
     self.update! quarantined: true
+    DataPoint.update_public_data_points('UHERO', self)
   end
 
   def remove_from_quarantine
     self.update! quarantined: false
+    DataPoint.update_public_data_points('UHERO', self)
   end
 
   def Series.empty_quarantine

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -19,11 +19,11 @@
 							:action => 'clear_and_reload', 
 							:id => ds.id} unless ds.eval.nil? 
 					%>&nbsp;|&nbsp;<%= 
-						link_to "delete",
-							:controller=> "data_sources", 
+						link_to "delete", {
+							:controller=> "data_sources",
 							:action => 'delete', 
-							:id => ds.id,
-							data: { :confirm => "Are you sure you want to delete this data source?" }
+							:id => ds.id },
+							data: { :confirm => "Are you sure you want to delete data source #{ds.id}?" }
 					%>&nbsp;<span style="color:gray">
 					&nbsp;|&nbsp;<%= 
 							link_to "edit", { 	

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -19,11 +19,11 @@
 							:action => 'clear_and_reload', 
 							:id => ds.id} unless ds.eval.nil? 
 					%>&nbsp;|&nbsp;<%= 
-						link_to "delete", { 	
+						link_to "delete",
 							:controller=> "data_sources", 
 							:action => 'delete', 
-							:id => ds.id}, 
-							:confirm => "Are you sure you want to delete this data source?" 
+							:id => ds.id,
+							data: { :confirm => "Are you sure you want to delete this data source?" }
 					%>&nbsp;<span style="color:gray">
 					&nbsp;|&nbsp;<%= 
 							link_to "edit", { 	

--- a/app/views/series/quarantine.html.erb
+++ b/app/views/series/quarantine.html.erb
@@ -2,8 +2,8 @@
 
 <h1>Listing Quarantined Series</h1>
 
-<p><%= link_to 'Empty quarantine', controller: 'series', action: 'empty_quarantine', id: 0,
-                       data: { :confirm => "Are you sure you want to clear ALL series from quarantine??" } %></p>
+<p><%= link_to 'Empty quarantine', { controller: 'series', action: 'empty_quarantine', id: 0 },
+                       data: { confirm: 'Are you sure you want to clear ALL series from quarantine??' } %></p>
 
 <table>
   <thead>

--- a/app/views/series/quarantine.html.erb
+++ b/app/views/series/quarantine.html.erb
@@ -2,7 +2,8 @@
 
 <h1>Listing Quarantined Series</h1>
 
-<p><%= link_to('Empty quarantine', controller: 'series', action: 'empty_quarantine', id: 0) %></p>
+<p><%= link_to('Empty quarantine', controller: 'series', action: 'empty_quarantine', id: 0,
+                       data: { :confirm => "Are you sure you want to clear ALL series from quarantine??") } %></p>
 
 <table>
   <thead>

--- a/app/views/series/quarantine.html.erb
+++ b/app/views/series/quarantine.html.erb
@@ -2,8 +2,8 @@
 
 <h1>Listing Quarantined Series</h1>
 
-<p><%= link_to('Empty quarantine', controller: 'series', action: 'empty_quarantine', id: 0,
-                       data: { :confirm => "Are you sure you want to clear ALL series from quarantine??") } %></p>
+<p><%= link_to 'Empty quarantine', controller: 'series', action: 'empty_quarantine', id: 0,
+                       data: { :confirm => "Are you sure you want to clear ALL series from quarantine??" } %></p>
 
 <table>
   <thead>

--- a/app/views/series/quarantine.html.erb
+++ b/app/views/series/quarantine.html.erb
@@ -3,14 +3,15 @@
 <h1>Listing Quarantined Series</h1>
 
 <p><%= link_to 'Empty quarantine', { controller: 'series', action: 'empty_quarantine', id: 0 },
-                       data: { confirm: 'Are you sure you want to clear ALL series from quarantine??' } %></p>
+                       data: { confirm: 'Are you sure you want to clear ALL series from quarantine??' } %>
+  (may take some time if there are many series quarantined)</p>
 
 <table>
   <thead>
   <tr>
     <th>Series</th>
     <th>Description</th>
-    <th colspan="3"></th>
+    <th colspan="2"></th>
     <th>Data Source Definitions</th>
   </tr>
   </thead>

--- a/app/views/series/quarantine.html.erb
+++ b/app/views/series/quarantine.html.erb
@@ -18,9 +18,8 @@
   <tbody>
   <% @series.each do |series| %>
       <tr>
-        <td><%= series.name %></td>
+        <td><%= link_to series.name, series %></td>
         <td><%= series.dataPortalName  %></td>
-        <td><%= link_to 'Show', series %></td>
         <td><%= link_to 'Edit', edit_series_path(series) %></td>
         <td><%= link_to('Unquarantine', action: 'remove_from_quarantine', id: series.id, next_action: 'quarantine') %></td>
         <td><%= series.data_sources.map { |ds| ds['eval'] }.join('<br />').html_safe %></td>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -57,7 +57,12 @@ google.visualization.events.addListener(chart, 'select', function() {
     <tr><td>Source Link</td><td><%= (@series.source_link.nil? || @series.source_link.empty?) ? (@series.source.link unless @series.source.nil?) : @series.source_link %></td></tr>
     <tr><td>Source Details</td><td><%= @series.source_detail.description unless @series.source_detail.nil? %></td></tr>
     <tr><td>Restricted</td><td><%= @series.restricted.to_s %></td></tr>
-    <tr><td>Quarantined</td><td><%= @series.quarantined.to_s %></td></tr>
+    <tr><td>Quarantined</td><td><%= @series.quarantined.to_s %>
+        <span id="series_controls">
+          <%= link_to('(add)', action: :add_to_quarantine, id: @series) unless @series.quarantined %>
+          <%= link_to('(remove)', action: :remove_from_quarantine, id: @series) if @series.quarantined %>
+       </span>
+    </td></tr>
   </table>
 
 	<div id="navigation">
@@ -71,11 +76,6 @@ google.visualization.events.addListener(chart, 'select', function() {
 		<%= link_to 'Outlier Chart', :action => 'outlier_graph', :id => @series %> |
 		<a href="/listseries/<%=@series.name.chop.chop%>">TSDs</a> |
 		<%= link_to 'CSV', :action => 'show', :format => :csv, :id => @series %> 
-
-    <div id="series_controls">
-      <%= link_to('Add to quarantine', action: 'add_to_quarantine', id: @series) unless @series.quarantined %>
-      <%= link_to('Unquarantine', action: 'remove_from_quarantine', id: @series) if @series.quarantined %>
-    </div>
 
 		<div id="chart_div"></div>
 		<div id="notes"><p><%= @series.investigation_notes %></p></div>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -57,12 +57,14 @@ google.visualization.events.addListener(chart, 'select', function() {
     <tr><td>Source Link</td><td><%= (@series.source_link.nil? || @series.source_link.empty?) ? (@series.source.link unless @series.source.nil?) : @series.source_link %></td></tr>
     <tr><td>Source Details</td><td><%= @series.source_detail.description unless @series.source_detail.nil? %></td></tr>
     <tr><td>Restricted</td><td><%= @series.restricted.to_s %></td></tr>
-    <tr><td>Quarantined</td><td><%= @series.quarantined.to_s %>
-        <span id="series_controls">
-          <%= link_to('(add)', action: :add_to_quarantine, id: @series) unless @series.quarantined %>
-          <%= link_to('(remove)', action: :remove_from_quarantine, id: @series) if @series.quarantined %>
-       </span>
-    </td></tr>
+    <% unless @series.restricted %>
+      <tr><td>Quarantined</td><td><%= @series.quarantined.to_s %>
+          <span id="series_controls">
+            <%= link_to('(add)', action: :add_to_quarantine, id: @series) unless @series.quarantined %>
+            <%= link_to('(remove)', action: :remove_from_quarantine, id: @series) if @series.quarantined %>
+         </span>
+      </td></tr>
+    <% end %>
   </table>
 
 	<div id="navigation">


### PR DESCRIPTION
Moved data-changing operations from controller into model methods.

`DataPoint.update_public_data_points` method used to return failure when called with a particular series if that series was quarantined. Now it deletes that series' dp from the public dp table. Some callers of this method are looking for failed return (bool `false`), which they never really would have gotten anyway, but I have now wrapped the DB calls in begin-rescue blocks, so that if one of those fails, this method will return false, otherwise always true.

Changed SQL code blocks in aforementioned method to use "squiggly heredoc" delimitation rather than plain strings, so that we can see syntax coloring in RubyMine, which I like :)
 
Change to `app/views/series/_source_list.html.erb` is just to fix bug in confirm dialog.

In series `#show` screen, quarantine metadata only displays if restricted = false. Controls to add and remove from quarantine moved up to (imho) more useful location.