### PR TITLE
Initial stage of dependency_depth fix (UA-843)

### DIFF
--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -110,7 +110,7 @@ class DataSource < ActiveRecord::Base
 
 
     def DataSource.set_dependencies
-      DataSource.all.find_each(batch_size: 50) do |ds|
+      DataSource.where(universe: 'UHERO').find_each(batch_size: 50) do |ds|
         ds.set_dependencies
       end
       return 0

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -110,9 +110,12 @@ class DataSource < ActiveRecord::Base
 
 
     def DataSource.set_dependencies
+      Rails.logger.info { 'DataSource set_dependencies: start' }
       DataSource.where(universe: 'UHERO').find_each(batch_size: 50) do |ds|
+        Rails.logger.debug { "DataSource set_dependencies: for #{ds.description}" }
         ds.set_dependencies
       end
+      Rails.logger.info { 'DataSource set_dependencies: done' }
       return 0
     end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -943,7 +943,9 @@ class Series < ActiveRecord::Base
 
   def Series.assign_dependency_depth
     # reset dependency_depth
-    ActiveRecord::Base.connection.execute('UPDATE series s SET dependency_depth = 0;')
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      UPDATE series SET dependency_depth = 0 WHERE universe = 'UHERO';
+    SQL
     previous_depth_count = Series.where(universe: 'UHERO', dependency_depth: 0).count
 
     # first level of dependencies

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -960,7 +960,8 @@ class Series < ActiveRecord::Base
     previous_depth = 1
     until current_depth_count == previous_depth_count
       Rails.logger.debug {
-        "Series assign_dependency_depth: at #{Time.now}: current_depth_count=#{current_depth_count}, previous_depth_count=#{previous_depth_count}" }
+        "Series assign_dependency_depth: at #{Time.now}: current_depth_count=#{current_depth_count}, previous_depth_count=#{previous_depth_count}"
+      }
       next_level_sql = <<~SQL
         UPDATE series s SET dependency_depth = #{previous_depth + 1}
         WHERE EXISTS (

--- a/lib/download/downloads_cache.rb
+++ b/lib/download/downloads_cache.rb
@@ -44,7 +44,7 @@ class DownloadsCache
 
   def mark_handle_used(handle)
     return unless handle =~ /@/
-    @cache[:used_dloads][handle] = @cache[:dloads][handle] || raise("No download handle #{handle} to mark")
+    @cache[:used_dloads][handle] = @cache[:dloads][handle] || raise("No download handle='#{handle}' to mark")
   end
 
   def update_last_used

--- a/lib/series_relationship.rb
+++ b/lib/series_relationship.rb
@@ -170,9 +170,10 @@ module SeriesRelationship
     self.data_sources_by_last_run.each do |ds| 
       begin
         ds.reload_source
-      rescue Exception
-        errors.push("DataSource #{ds.id} for #{self.name} : #{self.id}")
-        puts "SOMETHING BROKE with source #{ds.id} in series #{self.name} (#{self.id})-----------------------------------------------"
+      rescue => e
+        errors.push("DataSource #{ds.id} for #{self.name} (#{self.id}): #{e.message}")
+        Rails.logger.error { "SOMETHING BROKE (#{e.message}) with source #{ds.id} in series #{self.name} (#{self.id})" }
+        puts "SOMETHING BROKE (#{e.message}) with source #{ds.id} in series #{self.name} (#{self.id})-----------------------------------------------"
       end
     end
     errors

--- a/lib/tasks/source_map.rake
+++ b/lib/tasks/source_map.rake
@@ -36,7 +36,7 @@ task :reset_dependency_depth => :environment do
   t = Time.now
   DataSource.set_dependencies
   Series.assign_dependency_depth
-  puts (Time.now - t).to_s + ' seconds'
+  Rails.logger.info { "Reset dependency depth: Done in #{Time.now - t} seconds" }
 end
 
 desc 'Switch rails logger to stdout'


### PR DESCRIPTION
Just some added logging, and reformattting of SQL queries. There should be nothing in terms of functional change here, except limitation of `DataSource.set_dependencies` to operate only over UHERO sources rather than all.