### PR TITLE
List of BEA Series without an API source (UA-847)

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -94,6 +94,10 @@ class SeriesController < ApplicationController
                     .order(:name).paginate(page: params[:page], per_page: 50)
   end
 
+  def old_bea_download
+    @series = Series.get_old_bea_downloads
+  end
+
   def add_to_quarantine
     @series = Series.find_by id: params[:id]
     if @series

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -95,7 +95,7 @@ class SeriesController < ApplicationController
   end
 
   def old_bea_download
-    @series = Series.get_old_bea_downloads
+    @old_bea_series = Series.get_old_bea_downloads
   end
 
   def add_to_quarantine

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1028,4 +1028,16 @@ class Series < ActiveRecord::Base
       puts "Queued depth #{next_depth} (#{series_size})"
     end
   end
+
+  def Series.get_old_bea_downloads
+    series = []
+    Download.where(%q(handle like '%@bea.gov')).each do |dl|
+      dl.data_sources.each do |ds|
+        if ds.series.data_sources.select{|x| x.eval =~ /load_from_bea/ }.empty?
+          series.push ds.series
+        end
+      end
+    end
+    series
+  end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1033,11 +1033,11 @@ class Series < ActiveRecord::Base
     series = []
     Download.where(%q(handle like '%@bea.gov')).each do |dl|
       dl.data_sources.each do |ds|
-        if ds.series.data_sources.select{|x| x.eval =~ /load_from_bea/ }.empty?
+        if ds.series.data_sources.select{|x| x.eval =~ /load_from_(bea|bls|fred)/ }.empty?
           series.push ds.series
         end
       end
     end
-    series
+    series.sort{|x,y| x.name <=> y.name }
   end
 end

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -18,6 +18,10 @@
       <%= link_to 'Unrestricted series with no Source', controller: :series, action: 'no_source_no_restrict' %>
       <br />
       <%= link_to 'Quarantined Series', controller: :series, action: 'quarantine' %>
+      <br />
+      <%= link_to 'Series with stale source', controller: :series, action: :stale %>
+      <br />
+      <%= link_to 'BEA Series without an API source', controller: :series, action: :old_bea_download %>
     </div>
   <% end %>
 </div>
@@ -32,5 +36,3 @@
 </div>
 
 <p>
-	
-	

--- a/app/views/series/old_bea_download.html.erb
+++ b/app/views/series/old_bea_download.html.erb
@@ -1,0 +1,17 @@
+<div id="summary_area">
+	<h2>Data Series from BEA without an API source</h2>
+	<h2>Total: <%= @series.count %></h2>
+</div>
+<div id="details_mask"></div>
+<div id="details_area">
+		<ul>
+		<% @series.each do |id, hash| %>
+       <li><%= link_to hash[:name], { action: :show, id: id } %>
+         (<% hash[:dsids].each do |dsid| %>
+             <%= link_to dsid, { controller: :data_sources, action: :edit, id: dsid } %>
+          <% end %>)</li>
+    <% end %>
+		</ul>
+</div>
+
+<p>

--- a/app/views/series/old_bea_download.html.erb
+++ b/app/views/series/old_bea_download.html.erb
@@ -1,11 +1,11 @@
 <div id="summary_area">
 	<h2>BEA Series without an API source</h2>
-	<h2>Total: <%= @series.count %></h2>
+	<h2>Total: <%= @old_bea_series.count %></h2>
 </div>
 <div id="details_mask"></div>
 <div id="details_area">
 		<ul>
-		<% @series.order(:name).each do |series| %>
+		<% @old_bea_series.each do |series| %>
        <li><%= link_to series.name, series %>
       </li>
     <% end %>

--- a/app/views/series/old_bea_download.html.erb
+++ b/app/views/series/old_bea_download.html.erb
@@ -1,15 +1,13 @@
 <div id="summary_area">
-	<h2>Data Series from BEA without an API source</h2>
+	<h2>BEA Series without an API source</h2>
 	<h2>Total: <%= @series.count %></h2>
 </div>
 <div id="details_mask"></div>
 <div id="details_area">
 		<ul>
-		<% @series.each do |id, hash| %>
-       <li><%= link_to hash[:name], { action: :show, id: id } %>
-         (<% hash[:dsids].each do |dsid| %>
-             <%= link_to dsid, { controller: :data_sources, action: :edit, id: dsid } %>
-          <% end %>)</li>
+		<% @series.order(:name).each do |series| %>
+       <li><%= link_to series.name, series %>
+      </li>
     <% end %>
 		</ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ UheroDb::Application.routes.draw do
   get 'series/no_source', to: 'series#no_source'
   get 'series/no_source_no_restrict', to: 'series#no_source_no_restrict'
   get 'series/quarantine', to: 'series#quarantine'
+  get 'series/old_bea_download', to: 'series#old_bea_download'
 
   resources :series
 


### PR DESCRIPTION
A new screen. Should be self-explanatory.
Also, added **Series with stale source** link to the Series top page.