### PR TITLE
Reload-Nightly flag for data sources (UA-848)

### DIFF
--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -21,7 +21,13 @@ class DataSourcesController < ApplicationController
     source.delete
     redirect_to :controller=> 'series', :action => 'show', :id => source.series_id
   end
-  
+
+  def toggle_reload_nightly
+    source = DataSource.find_by id: params[:id]
+    source.toggle_reload_nightly
+    redirect_to controller: :series, action: :show, id: source.series_id
+  end
+
   def new
     #params.each { |key,value| puts "#{key}: #{value}" }
     @series = Series.find_by id: params[:series_id]
@@ -70,12 +76,6 @@ class DataSourcesController < ApplicationController
       @series = Series.find_by id: @data_source.series_id
       render :action => 'new', :series_id => @data_source.series_id
     end
-  end
-
-  def toggle_reload_nightly
-    source = DataSource.find_by id: params[:id]
-    source.toggle_reload_nightly
-    redirect_to controller: :series, action: :show, id: source.series_id
   end
 
   private

--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -72,6 +72,12 @@ class DataSourcesController < ApplicationController
     end
   end
 
+  def toggle_reload_nightly
+    source = DataSource.find_by id: params[:id]
+    source.toggle_reload_nightly
+    redirect_to controller: :series, action: :show, id: source.series_id
+  end
+
   private
     def data_source_params
       params.require(:data_source).permit(:series_id, :eval, :priority)

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -5,7 +5,7 @@ class DownloadsController < ApplicationController
   before_action :set_download, only: [:show, :edit, :update, :destroy, :download]
 
   def index
-    @output_files = Download.where(universe: 'UHERO').order(:url).all
+    @output_files = Download.order(:url).all
     @domain_hash = {}
     @output_files.each do |dl|
       if dl.url

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -114,15 +114,8 @@ module SeriesHelper
     count = Series.count
 	  html += link_to raw("all&nbsp;<span class='series_count'>#{count}</span>") , {:action => 'index', :all => 'true'}
   end
+
+  def nightly_actuator(nightly)
+    nightly ? 'nightly-Y' : 'nightly-N'
+  end
 end
-
-
-# array2d = []
-# array2d.push([""] + sorted_names)
-# dates_array.each do |date|
-#   array2d.push([date] + sorted_names.map {|series_name| series_data[series_name][date]})
-# end
-# csv << [""] + sorted_names
-# dates_array.each do |date|
-#   csv << [date] + sorted_names.map {|series_name| series_data[series_name][date]}
-# end

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -116,6 +116,6 @@ module SeriesHelper
   end
 
   def nightly_actuator(nightly)
-    nightly ? 'nightly' : 'NO NIGHTLY'
+    (nightly ? 'disable' : 'enable') + ' nightly reload'
   end
 end

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -116,6 +116,6 @@ module SeriesHelper
   end
 
   def nightly_actuator(nightly)
-    nightly ? 'nightly-Y' : 'nightly-N'
+    nightly ? 'nightly' : 'NO NIGHTLY'
   end
 end

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -254,6 +254,9 @@ class DataSource < ActiveRecord::Base
       super
     end
 
+    def toggle_reload_nightly
+      self.update_attributes!(reload_nightly: !self.reload_nightly)
+    end
 
     def set_color
       color_order = %w(FFCC99 CCFFFF 99CCFF CC99FF FFFF99 CCFFCC FF99CC CCCCFF 9999FF 99FFCC)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -280,7 +280,7 @@ class Series < ActiveRecord::Base
   end
 
   def Series.build_name(parts)
-    name = parts[0].strip + '@' + parts[1].strip + '.' + parts[2].strip
+    name = parts[0].strip.upcase + '@' + parts[1].strip.upcase + '.' + parts[2].strip.upcase
     Series.parse_name(name) ? name : raise("Build series name: '#{name}' format invalid")
   end
 

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -6,7 +6,8 @@
 	<% series.data_sources_by_last_run.each do |ds| %>
   	<% eval = ds.eval.nil? ? " " : ds.eval.split(" ").join("&nbsp;") %>
   	<tr style="background-color:#<%= ds.color%>" >
-  		<td><%= ds.last_run.localtime.strftime("%m/%d/%y") %>&nbsp;<span style="color:gray"><%= 		
+  		<td style="<%= 'border-left: 5px solid blue;' unless ds.reload_nightly %>">
+      <%= ds.last_run.localtime.strftime("%m/%d/%y") %>&nbsp;<span style="color:gray"><%=
 					ds.last_run.localtime.strftime("%H:%M:%S") %></span>&nbsp;(<%= ds.priority %>)<br />
  					<%= 
 						link_to "load", {   	
@@ -29,12 +30,9 @@
 								:controller=> "data_sources", 
 								:action => 'edit', 
 								:id => ds.id}
-					%>&nbsp;|&nbsp;<%=
-              link_to nightly_actuator(ds.reload_nightly), {controller: :data_sources, action: :toggle_reload_nightly, id: ds.id}
-          %><br/>
-          <span style="color:gray">(<%=
-						"#{ds.runtime.round(2)}s" unless ds.runtime.nil? 
-					%>)</span>
+					%>
+        <span style="color:gray">(<%= "#{ds.runtime.round(2)}s" unless ds.runtime.nil? %>)</span><br/>
+        <%= link_to nightly_actuator(ds.reload_nightly), {controller: :data_sources, action: :toggle_reload_nightly, id: ds.id} %>
         <% if ds.last_error %>
           <p>
             <span style='color:red;' title='<%= ds.last_error %>'>Last error<br/>
@@ -45,7 +43,7 @@
         <% end %>
   		</td>
 		<td>
-			<h3><%= ds.id %></h3>
+			<h3><%= ds.id %><% if ds.reload_nightly %> <i class="fa fa-moon-o" aria-hidden="true"></i><% end %></h3>
 			<%= raw linked_version(ds.description) %>
 			<br /> 
 			<%= raw eval %>

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -24,14 +24,14 @@
 							:action => 'delete', 
 							:id => ds.id },
 							data: { :confirm => "Are you sure you want to delete data source #{ds.id}?" }
-					%>&nbsp;|&nbsp;<%=
+					%><br/><%=
 							link_to "edit", { 	
 								:controller=> "data_sources", 
 								:action => 'edit', 
 								:id => ds.id}
 					%>&nbsp;|&nbsp;<%=
               link_to nightly_actuator(ds.reload_nightly), {controller: :data_sources, action: :toggle_reload_nightly, id: ds.id}
-          %>
+          %><br/>
           <span style="color:gray">(<%=
 						"#{ds.runtime.round(2)}s" unless ds.runtime.nil? 
 					%>)</span>

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -6,7 +6,7 @@
 	<% series.data_sources_by_last_run.each do |ds| %>
   	<% eval = ds.eval.nil? ? " " : ds.eval.split(" ").join("&nbsp;") %>
   	<tr style="background-color:#<%= ds.color%>" >
-  		<td style="<%= 'border-left: 5px solid blue;' unless ds.reload_nightly %>">
+  		<td>
       <%= ds.last_run.localtime.strftime("%m/%d/%y") %>&nbsp;<span style="color:gray"><%=
 					ds.last_run.localtime.strftime("%H:%M:%S") %></span>&nbsp;(<%= ds.priority %>)<br />
  					<%= 
@@ -43,7 +43,7 @@
         <% end %>
   		</td>
 		<td>
-			<h3><%= ds.id %><% if ds.reload_nightly %> <i class="fa fa-moon-o" aria-hidden="true"></i><% end %></h3>
+			<h3><%= ds.id %><% if ds.reload_nightly %> <i class="fa fa-clock-o" aria-hidden="true"></i><% end %></h3>
 			<%= raw linked_version(ds.description) %>
 			<br /> 
 			<%= raw eval %>

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -24,13 +24,15 @@
 							:action => 'delete', 
 							:id => ds.id },
 							data: { :confirm => "Are you sure you want to delete data source #{ds.id}?" }
-					%>&nbsp;<span style="color:gray">
-					&nbsp;|&nbsp;<%= 
+					%>&nbsp;|&nbsp;<%=
 							link_to "edit", { 	
 								:controller=> "data_sources", 
 								:action => 'edit', 
 								:id => ds.id}
-						%>&nbsp;<span style="color:gray">(<%= 
+					%>&nbsp;|&nbsp;<%=
+              link_to nightly_actuator(ds.reload_nightly), {controller: :data_sources, action: :toggle_reload_nightly, id: ds.id}
+          %>
+          <span style="color:gray">(<%=
 						"#{ds.runtime.round(2)}s" unless ds.runtime.nil? 
 					%>)</span>
         <% if ds.last_error %>

--- a/app/workers/series_worker.rb
+++ b/app/workers/series_worker.rb
@@ -28,7 +28,7 @@ class SeriesWorker
         redis.incr keys[:busy_workers]
       end
 
-      errors = Series.find(series_id).reload_sources
+      errors = Series.find(series_id).reload_sources(true)
       GC.start
       unless errors.nil?
         File.open('public/reload_errors.log', 'a') {|f| f.puts errors }

--- a/db/migrate/220170413025733_data_source_reload_nightly_flag.rb
+++ b/db/migrate/220170413025733_data_source_reload_nightly_flag.rb
@@ -1,0 +1,6 @@
+class DataSourceReloadNightlyFlag < ActiveRecord::Migration
+  def change
+    add_column :data_sources, :reload_nightly, :boolean, default: true, after: :updated_at
+    add_column :data_sources, :last_run_at, :datetime, after: :reload_nightly
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 220170413025732) do
+ActiveRecord::Schema.define(version: 220170413025733) do
 
   create_table "api_applications", force: :cascade do |t|
     t.string   "universe",        limit: 5,   default: "UHERO", null: false
@@ -167,6 +167,8 @@ ActiveRecord::Schema.define(version: 220170413025732) do
     t.float    "runtime",             limit: 24
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "reload_nightly",                                             default: true
+    t.datetime "last_run_at"
     t.decimal  "last_run_in_seconds",               precision: 17, scale: 3
     t.string   "last_error",          limit: 255
     t.datetime "last_error_at"

--- a/lib/series_relationship.rb
+++ b/lib/series_relationship.rb
@@ -165,11 +165,11 @@ module SeriesRelationship
     return 1
   end
     
-  def reload_sources
+  def reload_sources(series_worker = false)
     errors = []
     self.data_sources_by_last_run.each do |ds| 
       begin
-        ds.reload_source
+        ds.reload_source unless series_worker && !ds.reload_nightly
       rescue => e
         errors.push("DataSource #{ds.id} for #{self.name} (#{self.id}): #{e.message}")
         Rails.logger.error { "SOMETHING BROKE (#{e.message}) with source #{ds.id} in series #{self.name} (#{self.id})" }


### PR DESCRIPTION
Add a new property to Data Sources: `reload_nightly`, a boolean flag that will control whether the nightly reload tries to run this source or not.  See series#show screen sources list for a new functional actuator (right term?) which appears as **nightly** if `reload_nightly` is true, and **NO NIGHTLY** otherwise (please offer better UI ideas if you have them). Clicking the link toggles between the two values.

The display of the actuators in the sources list has been cleaned up a little bit, primarily to remove a useless pipe character (`|`) which was always appearing at the far left rather than between links.

Note that there are also three (count 'em) other things in this PR that don't quite belong:
* downloads_controller.rb: the permanent fix to a bug introduced by another PR that I fixed by editing the file in place, knowing that this would come up soon to "make it right".
* series.rb: Fix to force all series names to upper case before saving.
* Addition of another new datetime column in the migration, `last_run_at`, which is meant as a first step, and a reminder, to get around to refactoring the unnecessarily annoying storage of last-run information in seconds-since-epoch format.