### PR TITLE
Fix assignment of dependency depths (UA-849)

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -957,7 +957,8 @@ class Series < ActiveRecord::Base
     current_depth_count = Series.where(universe: 'UHERO', dependency_depth: 1).count
 
     previous_depth = 1
-    until current_depth_count == previous_depth_count
+    ##until current_depth_count == previous_depth_count
+    while current_depth_count > 0
       Rails.logger.debug {
         "Series assign_dependency_depth: at #{Time.now}: current_depth_count=#{current_depth_count}, previous_depth_count=#{previous_depth_count}"
       }

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -950,11 +950,10 @@ class Series < ActiveRecord::Base
     previous_depth_count = Series.where(universe: 'UHERO', dependency_depth: 0).count
 
     # first level of dependencies
-    first_level_sql = <<~SQL
+    ActiveRecord::Base.connection.execute(<<~SQL)
       UPDATE series s SET dependency_depth = 1
-      WHERE EXISTS (SELECT 1 FROM data_sources WHERE `dependencies` LIKE CONCAT('% ', s.`name`, '%'));
+      WHERE EXISTS (SELECT 1 FROM data_sources WHERE dependencies LIKE CONCAT('% ', s.name, '%'));
     SQL
-    ActiveRecord::Base.connection.execute(first_level_sql)
     current_depth_count = Series.where(universe: 'UHERO', dependency_depth: 1).count
 
     previous_depth = 1
@@ -962,15 +961,15 @@ class Series < ActiveRecord::Base
       Rails.logger.debug {
         "Series assign_dependency_depth: at #{Time.now}: current_depth_count=#{current_depth_count}, previous_depth_count=#{previous_depth_count}"
       }
-      next_level_sql = <<~SQL
+      ActiveRecord::Base.connection.execute(<<~SQL)
         UPDATE series s SET dependency_depth = #{previous_depth + 1}
         WHERE EXISTS (
           SELECT 1 FROM data_sources ds JOIN series inner_s ON ds.series_id = inner_s.id
           WHERE inner_s.dependency_depth = #{previous_depth}
-          AND ds.`dependencies` LIKE CONCAT('% ', REPLACE(s.`name`, '%', '\\%'), '%')
+          AND ds.dependencies LIKE CONCAT('% ', s.name, '%')
         );
       SQL
-      ActiveRecord::Base.connection.execute next_level_sql
+      ###AND ds.dependencies LIKE CONCAT('% ', REPLACE(s.name, '%', '\\%'), '%')
       previous_depth_count = current_depth_count
       current_depth_count = Series.where(universe: 'UHERO', dependency_depth: previous_depth + 1).count
       previous_depth += 1

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -957,7 +957,6 @@ class Series < ActiveRecord::Base
     current_depth_count = Series.where(universe: 'UHERO', dependency_depth: 1).count
 
     previous_depth = 1
-    ##until current_depth_count == previous_depth_count
     while current_depth_count > 0
       Rails.logger.debug {
         "Series assign_dependency_depth: at #{Time.now}: current_depth_count=#{current_depth_count}, previous_depth_count=#{previous_depth_count}"
@@ -970,7 +969,6 @@ class Series < ActiveRecord::Base
           AND ds.dependencies LIKE CONCAT('% ', s.name, '%')
         );
       SQL
-      ###AND ds.dependencies LIKE CONCAT('% ', REPLACE(s.name, '%', '\\%'), '%')
       previous_depth_count = current_depth_count
       current_depth_count = Series.where(universe: 'UHERO', dependency_depth: previous_depth + 1).count
       previous_depth += 1


### PR DESCRIPTION
I think the original code is working, although with a very slight inefficiency. Other than the "tightening up" of the code that makes the diffs hard to read (sorry), the only thing that has really changed is replacing `REPLACE(s.name, '%', '\\%')` inside the EXISTS subquery with just `s.name`, but since the names should not contain `%` anyway, this should not be functionally different. The only real change is the loop condition, which changed from `until current_depth_count == previous_depth_count` to `while current_depth_count > 0`, which should save only 1 wasted loop iteration at the end, but otherwise it should have been working. If the `REPLACE` was intended to do something important algorithmically that I'm missing, please advise.