### PR TITLE
Inf(inity) should not be generated by Series mtd method (UA-859)

### DIFF
--- a/lib/series_arithmetic.rb
+++ b/lib/series_arithmetic.rb
@@ -214,11 +214,13 @@ module SeriesArithmetic
     mtd_sum = 0
     mtd_month = nil
     data.sort.each do |date, value|
-      if date.month != mtd_month
-        mtd_month = date.month
-        mtd_sum = 0
+      month = date.month
+      if month == mtd_month
+        mtd_sum += value
+      else
+        mtd_sum = value
+        mtd_month = month
       end
-      mtd_sum += value
       new_series_data[date] = mtd_sum
     end
     new_transformation("Month to Date sum of #{name}", new_series_data)

--- a/lib/series_arithmetic.rb
+++ b/lib/series_arithmetic.rb
@@ -121,7 +121,7 @@ module SeriesArithmetic
     new_series_data = {}
     last = nil
     data.sort.each do |date, value|
-      if last
+      if last && (last != 0 || value == 0)
         new_series_data[date] = last == 0 ? 0 : (value - last) / last * 100
       end
       last = value
@@ -184,7 +184,7 @@ module SeriesArithmetic
     new_series_data = {}
     data.sort.each do |date, value|
       prev_value = data[date - 1.year]
-      if prev_value
+      if prev_value && (prev_value != 0 || value == 0)
         new_series_data[date] = prev_value == 0 ? 0 : (value - prev_value) / prev_value * 100
       end
     end

--- a/lib/series_arithmetic.rb
+++ b/lib/series_arithmetic.rb
@@ -121,14 +121,24 @@ module SeriesArithmetic
     new_series_data = {}
     last = nil
     data.sort.each do |date, value|
-      if last && (last != 0 || value == 0)
-        new_series_data[date] = last == 0 ? 0 : (value - last) / last * 100
+      pc = compute_percentage_change(value, last)
+      unless pc.nil?
+        new_series_data[date] = pc
       end
       last = value
     end
     new_transformation("Percentage Change of #{name}", new_series_data)
   end
-  
+
+  def compute_percentage_change(value, last)
+    case
+      when last.nil? then nil
+      when last == 0 && value != 0 then nil
+      when last == 0 && value == 0 then 0
+      else (value - last) / last * 100
+    end
+  end
+
   def absolute_change(id=nil)
     return faster_change(id) unless id.nil?
     new_series_data = {}
@@ -184,8 +194,9 @@ module SeriesArithmetic
     new_series_data = {}
     data.sort.each do |date, value|
       prev_value = data[date - 1.year]
-      if prev_value && (prev_value != 0 || value == 0)
-        new_series_data[date] = prev_value == 0 ? 0 : (value - prev_value) / prev_value * 100
+      pc = compute_percentage_change(value, prev_value)
+      unless pc.nil?
+        new_series_data[date] = pc
       end
     end
     new_transformation("Annualized Percentage Change of #{name}", new_series_data)

--- a/lib/series_arithmetic.rb
+++ b/lib/series_arithmetic.rb
@@ -178,7 +178,11 @@ module SeriesArithmetic
     last = {}
     data.sort.each do |date, value|
       month = date.month
-      new_series_data[date] = (value-last[month])/last[month]*100 unless last[month].nil?
+      new_series_data[date] = case last[month]
+                                when nil then nil
+                                when 0 then 0
+                                else (value - last[month]) / last[month] * 100
+                              end
       last[date.month] = value
     end
     new_transformation("Annualized Percentage Change of #{name}", new_series_data)
@@ -192,7 +196,11 @@ module SeriesArithmetic
     new_series_data = {}
     data.sort.each do |date, value|
       last_year_date = date - 1.year
-      new_series_data[date] = (value-data[last_year_date])/data[last_year_date]*100 unless data[last_year_date].nil?
+      new_series_data[date] = case data[last_year_date]
+                                when nil then nil
+                                when 0 then 0
+                                else (value - data[last_year_date]) / data[last_year_date] * 100
+                              end
     end
     new_transformation("Annualized Percentage Change of #{name}", new_series_data)
   end
@@ -227,7 +235,7 @@ module SeriesArithmetic
       mtd_sum += value
       new_series_data[date] = mtd_sum
     end
-    new_transformation("Month to Date sum of #{name}", new_series_data)    
+    new_transformation("Month to Date sum of #{name}", new_series_data)
   end
   
   def mtd

--- a/lib/series_arithmetic.rb
+++ b/lib/series_arithmetic.rb
@@ -220,13 +220,11 @@ module SeriesArithmetic
     mtd_sum = 0
     mtd_month = nil
     data.sort.each do |date, value|
-      month = date.month
-      if month == mtd_month
-        mtd_sum += value
-      else
-        mtd_sum = value
-        mtd_month = month
+      if date.month != mtd_month
+        mtd_month = date.month
+        mtd_sum = 0
       end
+      mtd_sum += value
       new_series_data[date] = mtd_sum
     end
     new_transformation("Month to Date sum of #{name}", new_series_data)    


### PR DESCRIPTION
Bug caused by the fact that the one-year-previous datapoint was zero (not nil), and thus division exception was thrown. Seems to be fixed based on test with this expression:
```
"VAPITJPNS@HI.D".ts.mtd
```
Found a few other examples of code in the same file where division-by-zero could happen in similar way, and put in the same solution. Assuming that returning zero for these cases rather than omitting the data point is the right behavior. If not, please advise. See comment below for another question, too.

Cleaned up an old unused method.