### PR TITLE
Filter BEA API responses based on the parameters we send (UA-860)

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -555,13 +555,13 @@ class Series < ActiveRecord::Base
   
   def Series.load_from_bea(frequency, dataset, parameters)
     series_data = DataHtmlParser.new.get_bea_series(dataset, parameters)
-    Series.new_transformation("loaded series with parameters: #{parameters} from bea website", series_data, Series.frequency_from_code(frequency))
+    Series.new_transformation("loaded dataset #{dataset} with parameters #{parameters} from BEA API", series_data, Series.frequency_from_code(frequency))
   end
   
   def load_from_bea(dataset, parameters)
     frequency = Series.frequency_from_code(self.name.split('.')[1])
     series_data = DataHtmlParser.new.get_bea_series(dataset, parameters)
-    Series.new_transformation("loaded series with parameters: #{parameters} for region #{region} from bea website", series_data, frequency)
+    Series.new_transformation("loaded dataset #{dataset} with parameters #{parameters} for region #{region} from BEA API", series_data, frequency)
   end
   
   def Series.load_from_bls(code, frequency)

--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -48,6 +48,7 @@ class DataHtmlParser
     raise 'No API key defined for BEA' unless api_key
     query_pars = parameters.map{|k, v| "#{k}=#{v}"}.join('&')
     @url = "http://www.bea.gov/api/data/?UserID=#{api_key}&method=GetData&datasetname=#{dataset}&#{query_pars}&ResultFormat=JSON&"
+    Rails.logger.debug { "Getting URL from BEA API: #{@url}" }
     @doc = self.download
     new_data = {}
     bea_data = JSON.parse self.content
@@ -64,8 +65,10 @@ class DataHtmlParser
 
   def request_match(request, data_point)
     dp = data_point.map{|k,v| [k.upcase, v] }.to_h
-    request.keys.each do |rkey|
-      if dp[rkey.upcase.to_s] && request[rkey].strip.upcase != 'ALL' && dp[rkey.upcase.to_s] != request[rkey]
+    request.keys.each do |key|
+      dp_value = dp[key.upcase.to_s].to_s
+      if !dp_value.blank? && request[key].to_s.strip.upcase != 'ALL' && dp_value != request[key].to_s
+        Rails.logger.debug { "Rejected match: key=#{key}, dp has |#{dp_value}|" }
         return false
       end
     end

--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -65,7 +65,9 @@ class DataHtmlParser
   def request_match(request, data_point)
     dp = data_point.map{|k,v| [k.upcase, v] }.to_h
     request.keys.each do |rkey|
-      return false if dp[rkey.upcase] && request[rkey].strip.upcase != 'ALL' && dp[rkey.upcase] != request[rkey]
+      if dp[rkey.upcase.to_s] && request[rkey].strip.upcase != 'ALL' && dp[rkey.upcase.to_s] != request[rkey]
+        return false
+      end
     end
     true
   end

--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -65,7 +65,7 @@ class DataHtmlParser
   def request_match(request, data_point)
     dp = data_point.map{|k,v| [k.upcase, v] }.to_h
     request.keys.each do |rkey|
-      return false if dp[rkey.upcase] && dp[rkey.upcase] != request[rkey]
+      return false if dp[rkey.upcase] && request[rkey].strip.upcase != 'ALL' && dp[rkey.upcase] != request[rkey]
     end
     true
   end

--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -53,7 +53,7 @@ class DataHtmlParser
     new_data = {}
     bea_data = JSON.parse self.content
     bea_data['BEAAPI']['Results']['Data'].each do |data_point|
-#      next unless request_match(parameters, data_point)
+      next unless request_match(parameters, data_point)
       time_period = data_point['TimePeriod']
       value = data_point['DataValue']
       if value && value.gsub(',','').is_numeric?

--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -53,11 +53,11 @@ class DataHtmlParser
     new_data = {}
     bea_data = JSON.parse self.content
     bea_data['BEAAPI']['Results']['Data'].each do |data_point|
-      next unless request_match(parameters, data_point)
+#      next unless request_match(parameters, data_point)
       time_period = data_point['TimePeriod']
       value = data_point['DataValue']
-      if value && value.is_numeric?
-        new_data[ get_date(time_period[0..3], time_period[4..-1]) ] = value.to_f
+      if value && value.gsub(',','').is_numeric?
+        new_data[ get_date(time_period[0..3], time_period[4..-1]) ] = value.gsub(',','').to_f
       end
     end
     new_data
@@ -68,7 +68,7 @@ class DataHtmlParser
     request.keys.each do |key|
       dp_value = dp[key.upcase.to_s].to_s
       if !dp_value.blank? && request[key].to_s.strip.upcase != 'ALL' && dp_value != request[key].to_s
-        Rails.logger.debug { "Rejected match: key=#{key}, dp has |#{dp_value}|" }
+        Rails.logger.debug { "Rejected match: key=#{key}, dp has '#{dp_value}'" }
         return false
       end
     end

--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -52,6 +52,7 @@ class DataHtmlParser
     new_data = {}
     bea_data = JSON.parse self.content
     bea_data['BEAAPI']['Results']['Data'].each do |data_point|
+      next unless request_match(parameters, data_point)
       time_period = data_point['TimePeriod']
       value = data_point['DataValue']
       if value && value.is_numeric?
@@ -60,7 +61,15 @@ class DataHtmlParser
     end
     new_data
   end
-  
+
+  def request_match(request, data_point)
+    dp = data_point.map{|k,v| [k.upcase, v] }.to_h
+    request.keys.each do |rkey|
+      return false if dp[rkey.upcase] && dp[rkey.upcase] != request[rkey]
+    end
+    true
+  end
+
   def doc
     @doc
   end

--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -67,7 +67,7 @@ class DataHtmlParser
     dp = data_point.map{|k,v| [k.upcase, v] }.to_h
     request.keys.each do |key|
       dp_value = dp[key.upcase.to_s].to_s
-      if !dp_value.blank? && request[key].to_s.strip.upcase != 'ALL' && dp_value != request[key].to_s
+      if !dp_value.blank? && request[key].to_s.strip.upcase !~ /^(ANY|X)$/ && dp_value != request[key].to_s
         Rails.logger.debug { "Rejected match: key=#{key}, dp has '#{dp_value}'" }
         return false
       end


### PR DESCRIPTION
The logic is this: if we pass a request parameter (key) `P`, if a response data point contains P and has the same value that we requested, then it is accepted. If P has a different value in the response, it is ignored. Response data points that _don't contain_ key P will still be accepted (this is common). If the value of P in the request is `ALL`, then all response values of P are accepted.

Needed to convert everything to strings with `.to_s` to get this to work. Still not 100% sure why, but learned that Ruby can be weird about hashes being indexed on strings vs symbols.

Testing this on NIPA revealed that Rails' `is_numeric?()` method does not accept strings like "303,451" (ie large numbers with commas) as numeric, so I am removing the commas.

The wording of `description` fields for resulting series is improved a bit.

## Testing
The only existing data source that I could find to test that could actually exercise the filtering functionality is the one that triggered this story (the others I tried returned only the same parameters as requested, or different ones that wouldn't cause filtering). 
```
 Series.load_from_bea('A', 'NIPA', { TableName: 'T10105', LineNumber: 1, Frequency: 'A', Year: 'ALL' }) 
```
Run in a rails console, and the resulting series should have 89 points. Debug traces showing which responses were rejected will be shown. The raw URL is also shown; pull this in a browser to check the values.