### PR TITLE
New Category create/edit UI (UA-873)

### DIFF
--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -1,12 +1,13 @@
 $(function() {
-    $('.toggler').click(function() {
+    $('.category_non_leaf').click(function() {
         var ul = $(this).parent().children('ul');
         ul.toggle();
+        var text = $(this).html();
         if (ul.is(':hidden')) {
-            $(this).html($(this).html().replace('-minus-', '-plus-'));
+            $(this).html(text.replace('-minus-', '-plus-'));
         }
         else {
-            $(this).html($(this).html().replace('-plus-', '-minus-'));
+            $(this).html(text.replace('-plus-', '-minus-'));
         }
     });
     $('#toggle_all').click(function () {
@@ -14,12 +15,12 @@ $(function() {
         if (text == 'Expand all') {
             $('.collapsible').show();
             $(this).html('Collapse all');
-            $('.toggler').html(this.html().replace('-plus-', '-minus-'));
+            $('.category_non_leaf').each(function() { $(this).html( $(this).html().replace('-plus-', '-minus-') ); });
         }
         else {
             $('.collapsible').hide();
             $(this).html('Expand all');
-            $('.toggler').html(this.html().replace('-minus-', '-plus-'));
+            $('.category_non_leaf').each(function() { $(this).html( $(this).html().replace('-minus-', '-plus-') ); });
         }
     });
     $("a[data-remote][data-toggle]").on("ajax:success", function(e, data, status, xhr) {

--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -1,31 +1,25 @@
 $(function() {
     $('.toggler').click(function() {
         var ul = $(this).parent().children('ul');
-        var now;
-        var next;
         ul.toggle();
         if (ul.is(':hidden')) {
-            now = 'minus';
-            next = 'plus';
+            $(this).html($(this).html().replace('-minus-', '-plus-'));
         }
         else {
-            now = 'plus';
-            next = 'minus';
+            $(this).html($(this).html().replace('-plus-', '-minus-'));
         }
-        var mytext = $(this).html();
-        $(this).html(mytext.replace(now, next));
     });
     $('#toggle_all').click(function () {
         var text = $(this).html();
         if (text == 'Expand all') {
             $('.collapsible').show();
-            $('.toggler').html('<i class="fa fa-minus-square" aria-hidden="true"></i> ');
             $(this).html('Collapse all');
+            $('.toggler').html(this.html().replace('-plus-', '-minus-'));
         }
         else {
             $('.collapsible').hide();
-            $('.toggler').html('<i class="fa fa-plus-square" aria-hidden="true"></i> ');
             $(this).html('Expand all');
+            $('.toggler').html(this.html().replace('-minus-', '-plus-'));
         }
     });
     $("a[data-remote][data-toggle]").on("ajax:success", function(e, data, status, xhr) {

--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -3,12 +3,14 @@ $(function() {
         var ul = $(this).parent().children('ul');
         ul.toggle();
         if (ul.is(':hidden')) {
-            icon = '<i class="fa fa-plus-square" aria-hidden="true"></i>';
+            now = 'plus';
+            next = 'minus';
         }
         else {
-            icon = '<i class="fa fa-minus-square" aria-hidden="true"></i>';
+            now = 'minus';
+            next = 'plus';
         }
-        $(this).html(icon)
+        $(this).html.replace(now, next);
     });
     $('#toggle_all').click(function () {
         var text = $(this).html();

--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -1,16 +1,19 @@
 $(function() {
     $('.toggler').click(function() {
         var ul = $(this).parent().children('ul');
+        var now;
+        var next;
         ul.toggle();
         if (ul.is(':hidden')) {
-            now = 'plus';
-            next = 'minus';
-        }
-        else {
             now = 'minus';
             next = 'plus';
         }
-        $(this).html.replace(now, next);
+        else {
+            now = 'plus';
+            next = 'minus';
+        }
+        var mytext = $(this).html();
+        $(this).html(mytext.replace(now, next));
     });
     $('#toggle_all').click(function () {
         var text = $(this).html();

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -5,3 +5,8 @@
 .hidden_cat_label {
   color: red;
 }
+
+.toggler {
+  font-weight:bold;
+  cursor:pointer;
+}

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -6,7 +6,11 @@
   color: red;
 }
 
-.toggler {
+.category_non_leaf {
   font-weight:bold;
   cursor:pointer;
+}
+
+.category_leaf {
+  font-weight:bold;
 }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -38,7 +38,7 @@ class CategoriesController < ApplicationController
   def update
     ## Don't put empty strings in the db
     if @category.update(category_params.map {|k,v| [k, v.blank? ? nil : v] }.to_h)
-      redirect_to @category, notice: 'Category was successfully updated.'
+      redirect_to categories_url, notice: 'Category was successfully updated.'
     else
       render :edit
     end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -104,6 +104,6 @@ class CategoriesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def category_params
-      params.require(:category).permit(:name, :parent_id, :data_list_id, :default_geo_id, :default_freq, :hidden)
+      params.require(:category).permit(:name, :parent_id, :data_list_id, :default_geo_id, :default_freq, :hidden, :header)
     end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,7 +2,7 @@ class CategoriesController < ApplicationController
   include Authorization
   
   before_action :check_authorization
-  before_action :set_category, only: [:show, :edit, :update, :destroy, :up, :down, :toggle_hidden]
+  before_action :set_category, only: [:show, :edit, :update, :destroy, :up, :down, :toggle_hidden, :add_child]
 
   # GET /categories
   def index
@@ -55,6 +55,11 @@ class CategoriesController < ApplicationController
       format.js { render nothing: true, status: 200 }
     end
     @category.update_attributes(:hidden => !@category.hidden)
+  end
+
+  def add_child
+    child = @category.add_child
+    redirect_to action: :edit, id: child.id
   end
 
   def up

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -9,10 +9,13 @@ module CategoriesHelper
       category_strings.push show_table(categories[i], i == 0, i + 1 == categories.length)
     }
 
-    "<li>#{list_item}\n" +
-        '<ul class="collapsible" style="display:none;list-style:none;">' <<
-          category_strings.join("\n") <<
-        "</ul></li>\n"
+    <<~HTML
+    <li>#{list_item}
+        <ul class="collapsible" style="display:none;list-style:none;">
+          #{category_strings.join("\n")}
+        </ul>
+    </li>
+    HTML
   end
 
   def category_path_breadcrumbs(category, extra_sep = false)

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -31,7 +31,7 @@ private
     menu = []
     if current_user.admin_user?
       menu.push order_section(leaf, first, last)
-      menu.push link_to('Add_child', {controller: :categories, action: :add_child, id: leaf}, remote: true, data: {toggle: 1})
+      menu.push link_to('Add_child', {controller: :categories, action: :add_child, id: leaf})
       menu.push link_to('Edit', edit_category_path(leaf))
     end
     if current_user.dev_user?

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -31,6 +31,7 @@ private
     menu = []
     if current_user.admin_user?
       menu.push order_section(leaf, first, last)
+      menu.push link_to('Add_child', {controller: :categories, action: :add_child, id: leaf}, remote: true, data: {toggle: 1})
       menu.push link_to('Edit', edit_category_path(leaf))
     end
     if current_user.dev_user?

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -12,11 +12,7 @@ module CategoriesHelper
       category_strings.push show_table(categories[i], i == 0, i + 1 == categories.length)
     }
 
-    ## Note: the span element of class "toggler" below is closed inside the function show_list_item(), in the beginning
-    ## part of the variable 'name_part'. Yes, it's ugly as sin, but the only way I could make the category names clickable
-    ## (I felt a much needed UX improvement) without completely rewriting the code. If you rewrite the code, make sure to
-    ## fix this :=P -dji
-    '<li><span class="toggler" style="cursor:pointer;cursor:hand;"><i class="fa fa-plus-square" aria-hidden="true"></i> ' <<
+    '<li><span class="toggler"><i class="fa fa-plus-square" aria-hidden="true"></i></span> ' <<
     show_list_item(root, first, last) << "\n"+'<ul class="collapsible" style="display:none;list-style:none;">' <<
     category_strings.join("\n") <<
     '</ul></li>'+"\n"
@@ -30,14 +26,16 @@ module CategoriesHelper
 
 private
   def show_list_item(leaf, first, last)
-    if leaf.data_list
-      data_list_section = link_to(leaf.data_list.name, "data_lists/super_table/#{leaf.data_list_id}")
-    else
-      data_list_section = 'No Data List'
+    data_list_section =
+        case
+          when leaf.data_list then link_to(leaf.data_list.name, "data_lists/super_table/#{leaf.data_list_id}")
+          when leaf.header then 'Header'
+          else 'No Data List'
+        end
+    name_part = '<span class="toggler">%s</span> (%s)' % [leaf.name, data_list_section]
+    unless leaf.default_geo_id.blank? && leaf.default_freq.blank?
+      name_part += ' [%s.%s]' % [leaf.default_geo_handle, leaf.default_freq]
     end
-
-    name_part = "<strong>#{leaf.name}</strong></span> (#{data_list_section})"
-    name_part += " [#{leaf.default_geo_handle}.#{leaf.default_freq}]" unless leaf.default_geo_id.blank? && leaf.default_freq.blank?
     menu = []
     if current_user.admin_user?
       menu.push order_section(leaf, first, last)

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,7 +1,7 @@
 module CategoriesHelper
   def show_table(root, first, last)
     if root.is_childless?
-      return '<li><span><i class="fa fa-square" aria-hidden="true"></i></span> ' <<
+      return '<li><span><i class="fa fa-square" aria-hidden="true"></i> ' <<
           show_list_item(root, first, last) <<
           '</li>'+"\n"
     end
@@ -12,7 +12,11 @@ module CategoriesHelper
       category_strings.push show_table(categories[i], i == 0, i + 1 == categories.length)
     }
 
-    '<li><span class="toggler" style="cursor:pointer;cursor:hand;"><i class="fa fa-plus-square" aria-hidden="true"></i></span> ' <<
+    ## Note: the span element of class "toggler" below is closed inside the function show_list_item(), in the beginning
+    ## part of the variable 'name_part'. Yes, it's ugly as sin, but the only way I could make the category names clickable
+    ## (I felt a much needed UX improvement) without completely rewriting the code. Same thing is going on in the if block
+    ## at the top of this function. If you rewrite the code, make sure to fix this :=P -dji
+    '<li><span class="toggler" style="cursor:pointer;cursor:hand;"><i class="fa fa-plus-square" aria-hidden="true"></i> ' <<
     show_list_item(root, first, last) << "\n"+'<ul class="collapsible" style="display:none;list-style:none;">' <<
     category_strings.join("\n") <<
     '</ul></li>'+"\n"
@@ -32,7 +36,7 @@ private
       data_list_section = 'No Data List'
     end
 
-    name_part = "<strong>#{leaf.name}</strong> (#{data_list_section})"
+    name_part = "<strong>#{leaf.name}</strong></span> (#{data_list_section})"
     name_part += " [#{leaf.default_geo_handle}.#{leaf.default_freq}]" unless leaf.default_geo_id.blank? && leaf.default_freq.blank?
     menu = []
     if current_user.admin_user?

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,7 +1,7 @@
 module CategoriesHelper
   def show_table(root, first, last)
     if root.is_childless?
-      return '<li><span><i class="fa fa-square" aria-hidden="true"></i> ' <<
+      return '<li><span><i class="fa fa-square" aria-hidden="true"></i></span> ' <<
           show_list_item(root, first, last) <<
           '</li>'+"\n"
     end
@@ -14,8 +14,8 @@ module CategoriesHelper
 
     ## Note: the span element of class "toggler" below is closed inside the function show_list_item(), in the beginning
     ## part of the variable 'name_part'. Yes, it's ugly as sin, but the only way I could make the category names clickable
-    ## (I felt a much needed UX improvement) without completely rewriting the code. Same thing is going on in the if block
-    ## at the top of this function. If you rewrite the code, make sure to fix this :=P -dji
+    ## (I felt a much needed UX improvement) without completely rewriting the code. If you rewrite the code, make sure to
+    ## fix this :=P -dji
     '<li><span class="toggler" style="cursor:pointer;cursor:hand;"><i class="fa fa-plus-square" aria-hidden="true"></i> ' <<
     show_list_item(root, first, last) << "\n"+'<ul class="collapsible" style="display:none;list-style:none;">' <<
     category_strings.join("\n") <<

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -18,6 +18,12 @@ module CategoriesHelper
     '</ul></li>'+"\n"
   end
 
+  def category_path_breadcrumbs(category, extra_sep = false)
+    path = category.get_path_from_root
+    path.push '' if extra_sep
+    path.join(' > ').html_safe
+  end
+
 private
   def show_list_item(leaf, first, last)
     if leaf.data_list

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,10 +1,7 @@
 module CategoriesHelper
   def show_table(root, first, last)
-    if root.is_childless?
-      return '<li><span><i class="fa fa-square" aria-hidden="true"></i></span> ' <<
-          show_list_item(root, first, last) <<
-          '</li>'+"\n"
-    end
+    list_item = show_list_item(root, first, last)
+    return "<li>#{list_item}</li>\n" if root.is_childless?
 
     categories = (root.children.to_a).sort_by!{ |cat| cat.list_order }
     category_strings = []
@@ -12,10 +9,10 @@ module CategoriesHelper
       category_strings.push show_table(categories[i], i == 0, i + 1 == categories.length)
     }
 
-    '<li><span class="toggler"><i class="fa fa-plus-square" aria-hidden="true"></i></span> ' <<
-    show_list_item(root, first, last) << "\n"+'<ul class="collapsible" style="display:none;list-style:none;">' <<
-    category_strings.join("\n") <<
-    '</ul></li>'+"\n"
+    "<li>#{list_item}\n" +
+        '<ul class="collapsible" style="display:none;list-style:none;">' <<
+          category_strings.join("\n") <<
+        "</ul></li>\n"
   end
 
   def category_path_breadcrumbs(category, extra_sep = false)
@@ -26,13 +23,15 @@ module CategoriesHelper
 
 private
   def show_list_item(leaf, first, last)
+    span_class = leaf.is_childless? ? 'category_leaf' : 'category_non_leaf'
+    icon_type = leaf.is_childless? ? 'fa-square' : 'fa-plus-square'
     data_list_section =
         case
           when leaf.data_list then link_to(leaf.data_list.name, "data_lists/super_table/#{leaf.data_list_id}")
           when leaf.header then 'Header'
           else 'No Data List'
         end
-    name_part = '<span class="toggler">%s</span> (%s)' % [leaf.name, data_list_section]
+    name_part = '<span class="%s"><i class="fa %s" aria-hidden="true"></i> %s</span> (%s)' % [span_class, icon_type, leaf.name, data_list_section]
     unless leaf.default_geo_id.blank? && leaf.default_freq.blank?
       name_part += ' [%s.%s]' % [leaf.default_geo_handle, leaf.default_freq]
     end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,11 +6,12 @@ class Category < ActiveRecord::Base
 
   def add_child
     child_ancestry = "#{ancestry}/#{id}"
+    max_sib = Category.where(ancestry: child_ancestry).maximum(:list_order)
     Category.create(universe: universe,
                     name: 'New child',
                     ancestry: child_ancestry,
                     hidden: hidden,
-                    list_order: Category.where(ancestry: child_ancestry).maximum(:list_order) + 1)
+                    list_order: max_sib.nil? ? 0 : max_sib + 1)
   end
 
   def set_list_order

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,13 +5,22 @@ class Category < ActiveRecord::Base
   before_save :set_list_order
 
   def add_child
-    child_ancestry = "#{ancestry}/#{id}"
+    child_ancestry = ancestry ? "#{ancestry}/#{id}" : id
     max_sib = Category.where(ancestry: child_ancestry).maximum(:list_order)
     Category.create(universe: universe,
                     name: 'New child',
                     ancestry: child_ancestry,
                     hidden: hidden,
                     list_order: max_sib.nil? ? 0 : max_sib + 1)
+  end
+
+  def get_path_from_root
+    path = []
+    return path if ancestry.blank?
+    ancestry.split('/').each do |id|
+      path.push Category.find(id).name rescue 'Unknown category'
+    end
+    path
   end
 
   def set_list_order

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,6 +4,15 @@ class Category < ActiveRecord::Base
   belongs_to :default_geo, class_name: 'Geography'  ## in other words this model's `default_geo_id` is a Geography.id
   before_save :set_list_order
 
+  def add_child
+    child_ancestry = "#{ancestry}/#{id}"
+    Category.create(universe: universe,
+                    name: 'New child',
+                    ancestry: child_ancestry,
+                    hidden: hidden,
+                    list_order: Category.where(ancestry: child_ancestry).maximum(:list_order) + 1)
+  end
+
   def set_list_order
     return if self.list_order
     self.list_order = 0

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -11,6 +11,7 @@
     </div>
   <% end %>
 
+  <h4><%= category_path_breadcrumbs(@category, true) %></h4>
   <div class="field">
     <%= f.label :name %><br>
     <%= f.text_field :name, :size => 80 %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -18,16 +18,12 @@
     <%= f.check_box :hidden %>
   </div>
   <div class="field">
-    <%= f.label :parent_id %><br>
-    <%= f.collection_select :parent_id, Category.get_all(request.path =~ /edit/ ? @category.id : nil), :id, :name_with_depth, {:include_blank => true}%>
-  </div>
-  <div class="field">
     <%= f.label :data_list_id %><br>
-    <%= f.collection_select :data_list_id, DataList.where(universe: 'UHERO').all.order(:name), :id, :name, {:include_blank => true} %>
+    <%= f.collection_select :data_list_id, DataList.where(universe: @category.universe).all.order(:name), :id, :name, {:include_blank => true} %>
   </div>
   <div class="field">
     <%= f.label :default_geo_id, 'Default geography' %><br>
-    <%= f.collection_select :default_geo_id, Geography.where(universe: 'UHERO').order(:handle), :id, :handle_with_name, { :include_blank => true } %>
+    <%= f.collection_select :default_geo_id, Geography.where(universe: @category.universe).order(:handle), :id, :handle_with_name, { :include_blank => true } %>
   </div>
   <div class="field">
     <%= f.label :default_freq, 'Default frequency' %><br>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -17,6 +17,8 @@
     <%= f.text_field :name, :size => 80 %>
     Hidden?
     <%= f.check_box :hidden %>
+    Header?
+    <%= f.check_box :header %>
   </div>
   <div class="field">
     <%= f.label :data_list_id %><br>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -2,5 +2,4 @@
 
 <%= render 'form' %>
 
-<%= link_to 'Show', @category %> |
 <%= link_to 'Back', categories_path %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -2,7 +2,6 @@
 
 <h1>Listing Categories</h1>
 
-<%= link_to 'New Category', new_category_path if current_user.admin_user? %>
 <p>
 <span id="toggle_all" style="cursor:pointer;cursor:hand;">Expand all</span>
 </p>

--- a/db/migrate/220170413025734_add_new_universe_hawaii_county.rb
+++ b/db/migrate/220170413025734_add_new_universe_hawaii_county.rb
@@ -1,0 +1,34 @@
+class AddNewUniverseHawaiiCounty < ActiveRecord::Migration
+  def self.up
+    change_column :api_applications, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :categories, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :data_lists, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :data_points, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :data_sources, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :feature_toggles, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :geographies, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :measurements, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :public_data_points, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :series, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :source_details, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :sources, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :units, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+    change_column :users, :universe, %q(ENUM('UHERO','DBEDT','NTA','COH')), null: false, default: 'UHERO'
+  end
+  def self.down
+    change_column :api_applications, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :categories, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :data_lists, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :data_points, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :data_sources, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :feature_toggles, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :geographies, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :measurements, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :public_data_points, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :series, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :source_details, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :sources, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :units, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+    change_column :users, :universe, %q(ENUM('UHERO','DBEDT','NTA')), null: false, default: 'UHERO'
+  end
+end

--- a/db/migrate/220170413025735_add_header_col_to_categories.rb
+++ b/db/migrate/220170413025735_add_header_col_to_categories.rb
@@ -1,0 +1,5 @@
+class AddHeaderColToCategories < ActiveRecord::Migration
+  def change
+    add_column :categories, :header, :boolean, default: false
+  end
+end

--- a/db/migrate/220170413025735_add_header_col_to_categories.rb
+++ b/db/migrate/220170413025735_add_header_col_to_categories.rb
@@ -1,5 +1,5 @@
 class AddHeaderColToCategories < ActiveRecord::Migration
   def change
-    add_column :categories, :header, :boolean, default: false
+    add_column :categories, :header, :boolean, default: false, after: :hidden
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 220170413025733) do
+ActiveRecord::Schema.define(version: 220170413025735) do
 
   create_table "api_applications", force: :cascade do |t|
     t.string   "universe",        limit: 5,   default: "UHERO", null: false
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 220170413025733) do
     t.datetime "created_at",                                   null: false
     t.datetime "updated_at",                                   null: false
     t.boolean  "hidden",                     default: false
+    t.boolean  "header",                     default: false
     t.integer  "list_order",     limit: 4
     t.integer  "order",          limit: 4
     t.string   "ancestry",       limit: 255

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -102,10 +102,10 @@ RSpec.describe CategoriesController, type: :controller do
         expect(assigns(:category)).to eq(category)
       end
 
-      it 'redirects to the category' do
+      it 'redirects to the categories list' do
         category = Category.create! valid_attributes
         put :update, {id: category.to_param, category: valid_attributes}
-        expect(response).to redirect_to(category)
+        expect(response).to redirect_to(categories_url)
       end
     end
 

--- a/spec/views/categories/edit.html.erb_spec.rb
+++ b/spec/views/categories/edit.html.erb_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe "categories/edit", type: :view do
 
       assert_select "input#category_name[name=?]", "category[name]"
 
-      assert_select "select#category_parent_id[name=?]", "category[parent_id]"
-
       assert_select "select#category_data_list_id[name=?]", "category[data_list_id]"
     end
   end

--- a/spec/views/categories/index.html.erb_spec.rb
+++ b/spec/views/categories/index.html.erb_spec.rb
@@ -23,6 +23,6 @@ RSpec.describe 'categories/index', type: :view do
     view.stub(:current_user).and_return(user)
     controller.stub(:current_user).and_return(user)
     render
-    assert_select 'ul>li>strong', :text => 'Name'.to_s, :count => 2
+    assert_select 'ul>li>span', :text => 'Name'.to_s, :count => 2
   end
 end

--- a/spec/views/categories/new.html.erb_spec.rb
+++ b/spec/views/categories/new.html.erb_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe "categories/new", type: :view do
 
       assert_select "input#category_name[name=?]", "category[name]"
 
-      assert_select "select#category_parent_id[name=?]", "category[parent_id]"
-
       assert_select "select#category_data_list_id[name=?]", "category[data_list_id]"
     end
   end


### PR DESCRIPTION
A variety of UI improvements to the Category resource, along with some code refactoring.
* `Add_child` added to the per-item menu, creates a new child category
* Parent selection removed from the edit screen - no longer needed
* `Header` boolean column added to table, and checkbox for this property added to edit screen. Header cats show "Header" in the place in the index where leaves have a data list.
* Category names are now clickable, not just the icons
* Saving a category takes you right back to index now, rather than a useless `#show` screen.
* Edit screen now show breadcrumbs of the path from the root down to present category.

Next thing desperately needed (but not for this story): when you return to the index after editing, the tree remains expanded in the way you last left it...
