### PR TITLE
Easy creation of data list attached to a category (UA-878)

### DIFF
--- a/app/controllers/data_lists_controller.rb
+++ b/app/controllers/data_lists_controller.rb
@@ -118,8 +118,7 @@ class DataListsController < ApplicationController
   # GET /data_lists/new
   # GET /data_lists/new.xml
   def new
-    category = Category.find(params[:category_id]) rescue nil
-    @category_id = category.id if category
+    @category_id = Category.find(params[:category_id]).id rescue nil
     @data_list = DataList.new
 
     respond_to do |format|

--- a/app/controllers/data_lists_controller.rb
+++ b/app/controllers/data_lists_controller.rb
@@ -118,6 +118,8 @@ class DataListsController < ApplicationController
   # GET /data_lists/new
   # GET /data_lists/new.xml
   def new
+    category = Category.find(data_list_params[:category_id]) rescue nil
+    @category_id = category.id if category
     @data_list = DataList.new
 
     respond_to do |format|
@@ -155,7 +157,7 @@ class DataListsController < ApplicationController
 
     respond_to do |format|
       if @data_list.save
-        category = Category.find data_list_params[:category_id] rescue nil
+        category = Category.find(data_list_params[:category_id]) rescue nil
         if category
           category.update_attributes(data_list_id: @data_list.id)
           format.html { redirect_to edit_category_path(category) }

--- a/app/controllers/data_lists_controller.rb
+++ b/app/controllers/data_lists_controller.rb
@@ -126,6 +126,11 @@ class DataListsController < ApplicationController
     end
   end
 
+  def new_for_category
+    category_id = params[:category_id]
+    @data_list = DataList.new
+  end
+
   def duplicate
     original_data_list = DataList.find_by id: params[:id]
     new_data_list = original_data_list.dup

--- a/app/controllers/data_lists_controller.rb
+++ b/app/controllers/data_lists_controller.rb
@@ -126,11 +126,6 @@ class DataListsController < ApplicationController
     end
   end
 
-  def new_for_category
-    category_id = params[:category_id]
-    @data_list = DataList.new
-  end
-
   def duplicate
     original_data_list = DataList.find_by id: params[:id]
     new_data_list = original_data_list.dup
@@ -160,6 +155,12 @@ class DataListsController < ApplicationController
 
     respond_to do |format|
       if @data_list.save
+        category = Category.find data_list_params[:category_id] rescue nil
+        if category
+          category.update_attributes(data_list_id: @data_list.id)
+          format.html { redirect_to edit_category_path(category) }
+          return
+        end
         format.html { redirect_to(@data_list, :notice => 'Data list was successfully created.') }
         format.xml  { render :xml => @data_list, :status => :created, :location => @data_list }
       else
@@ -302,7 +303,8 @@ class DataListsController < ApplicationController
   private
     def data_list_params
       params.require(:data_list)
-          .permit(:name, :list, :startyear, :created_by, :updated_by, :owned_by, :measurements, :measurement_id, :indent_in_out)
+          .permit(:name, :list, :startyear, :created_by, :updated_by, :owned_by, :measurements, :measurement_id,
+                  :indent_in_out, :category_id)
     end
 
     def set_dates(frequency, params)

--- a/app/controllers/data_lists_controller.rb
+++ b/app/controllers/data_lists_controller.rb
@@ -153,10 +153,10 @@ class DataListsController < ApplicationController
   # POST /data_lists
   # POST /data_lists.xml
   def create
-    properties = data_list_params.merge({ :created_by => current_user.id, :updated_by => current_user.id, :owned_by => current_user.id })
+    properties = data_list_params.merge(created_by: current_user.id, updated_by: current_user.id, owned_by: current_user.id)
     category = Category.find(params[:category_id]) rescue nil
     properties.merge!(universe: category.universe) if category
-    @data_list = DataList.new properties
+    @data_list = DataList.new(properties)
 
     respond_to do |format|
       if @data_list.save
@@ -165,7 +165,7 @@ class DataListsController < ApplicationController
             category.update_attributes(data_list_id: @data_list.id)
             redirect_to edit_category_path(category)
           else
-            redirect_to(@data_list, :notice => 'Data list was successfully created.')
+            redirect_to(@data_list, notice: 'Data list was successfully created.')
           end
         }
         format.xml  { render :xml => @data_list, :status => :created, :location => @data_list }

--- a/app/controllers/data_lists_controller.rb
+++ b/app/controllers/data_lists_controller.rb
@@ -118,7 +118,7 @@ class DataListsController < ApplicationController
   # GET /data_lists/new
   # GET /data_lists/new.xml
   def new
-    category = Category.find(data_list_params[:category_id]) rescue nil
+    category = Category.find(params[:category_id]) rescue nil
     @category_id = category.id if category
     @data_list = DataList.new
 
@@ -153,17 +153,21 @@ class DataListsController < ApplicationController
   # POST /data_lists
   # POST /data_lists.xml
   def create
-    @data_list = DataList.new  data_list_params.merge({ :created_by => current_user.id, :updated_by => current_user.id, :owned_by => current_user.id })
+    properties = data_list_params.merge({ :created_by => current_user.id, :updated_by => current_user.id, :owned_by => current_user.id })
+    category = Category.find(params[:category_id]) rescue nil
+    properties.merge!(universe: category.universe) if category
+    @data_list = DataList.new properties
 
     respond_to do |format|
       if @data_list.save
-        category = Category.find(data_list_params[:category_id]) rescue nil
-        if category
-          category.update_attributes(data_list_id: @data_list.id)
-          format.html { redirect_to edit_category_path(category) }
-          return
-        end
-        format.html { redirect_to(@data_list, :notice => 'Data list was successfully created.') }
+        format.html {
+          if category
+            category.update_attributes(data_list_id: @data_list.id)
+            redirect_to edit_category_path(category)
+          else
+            redirect_to(@data_list, :notice => 'Data list was successfully created.')
+          end
+        }
         format.xml  { render :xml => @data_list, :status => :created, :location => @data_list }
       else
         format.html { render :action => 'new' }
@@ -305,8 +309,7 @@ class DataListsController < ApplicationController
   private
     def data_list_params
       params.require(:data_list)
-          .permit(:name, :list, :startyear, :created_by, :updated_by, :owned_by, :measurements, :measurement_id,
-                  :indent_in_out, :category_id)
+          .permit(:name, :list, :startyear, :created_by, :updated_by, :owned_by, :measurements, :measurement_id, :indent_in_out)
     end
 
     def set_dates(frequency, params)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -8,7 +8,7 @@ class Category < ActiveRecord::Base
     child_ancestry = ancestry ? "#{ancestry}/#{id}" : id
     max_sib = Category.where(ancestry: child_ancestry).maximum(:list_order)
     Category.create(universe: universe,
-                    name: 'New child',
+                    name: 'XXX New child XXX',
                     ancestry: child_ancestry,
                     hidden: hidden,
                     list_order: max_sib.nil? ? 0 : max_sib + 1)

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -23,6 +23,7 @@
   <div class="field">
     <%= f.label :data_list_id %><br>
     <%= f.collection_select :data_list_id, DataList.where(universe: @category.universe).all.order(:name), :id, :name, {:include_blank => true} %>
+    or <%= link_to 'Create a new data list for this category', {controller: :data_lists, action: :new_for_category, category_id: @category.id} %>
   </div>
   <div class="field">
     <%= f.label :default_geo_id, 'Default geography' %><br>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -23,7 +23,10 @@
   <div class="field">
     <%= f.label :data_list_id %><br>
     <%= f.collection_select :data_list_id, DataList.where(universe: @category.universe).all.order(:name), :id, :name, {:include_blank => true} %>
-      or <%= link_to 'Create a new data list for this category', {controller: :data_lists, action: :new, category_id: @category.id} %>
+      <% if @category.data_list %>
+        <%= link_to 'Edit this data list', edit_data_list_path(@category.data_list) %> or
+      <% end %>
+      <%= link_to 'Create a new data list for this category', {controller: :data_lists, action: :new, category_id: @category.id} %>*
   </div>
   <div class="field">
     <%= f.label :default_geo_id, 'Default geography' %><br>
@@ -37,6 +40,7 @@
     <%= f.submit %>
   </div>
 <% end %>
+<p>* If you click a link before saving this screen, entered data may be lost.</p>
 
 <script>
   $(document).ready(function() { $("#category_data_list_id").select2(); $("#category_parent_id").select2(); })

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -23,7 +23,7 @@
   <div class="field">
     <%= f.label :data_list_id %><br>
     <%= f.collection_select :data_list_id, DataList.where(universe: @category.universe).all.order(:name), :id, :name, {:include_blank => true} %>
-    or <%= link_to 'Create a new data list for this category', {controller: :data_lists, action: :new_for_category, category_id: @category.id} %>
+      or <%= link_to 'Create a new data list for this category', {controller: :data_lists, action: :new, category_id: @category.id} %>
   </div>
   <div class="field">
     <%= f.label :default_geo_id, 'Default geography' %><br>

--- a/app/views/data_lists/_form.html.erb
+++ b/app/views/data_lists/_form.html.erb
@@ -26,7 +26,7 @@
     </div>
   <% end %>
   <div class="actions">
-    <%= f.hidden_field :category_id %>
+    <%= hidden_field_tag(:category_id, @category_id) %>
     <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/data_lists/_form.html.erb
+++ b/app/views/data_lists/_form.html.erb
@@ -13,16 +13,18 @@
 
   <div class="field">
     <%= f.label :name %><br />
-    <%= f.text_field :name %>
+    <%= f.text_field :name, size: 60 %>
   </div>
   <div class="field">
     <%= f.label :startyear %><br />
-    <%= f.text_field :startyear %>
+    <%= f.text_field :startyear, size: 4 %> (YYYY)
   </div>
-  <div class="field">
-    <%= f.label :owned_by %><br />
-    <%= f.select(:owned_by, User.where(universe: 'UHERO').all.map {|u| [u.email, u.id]}, :prompt => 'Owned by') %>
-  </div>
+  <% if current_user.admin_user? %>
+    <div class="field">
+      <%= f.label :owned_by %><br />
+      <%= f.select(:owned_by, User.where(universe: 'UHERO').all.map {|u| [u.email, u.id]}, :prompt => 'Owned by') %>
+    </div>
+  <% end %>
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/app/views/data_lists/_form.html.erb
+++ b/app/views/data_lists/_form.html.erb
@@ -26,6 +26,7 @@
     </div>
   <% end %>
   <div class="actions">
+    <%= f.hidden_field :category_id %>
     <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/data_lists/new.html.erb
+++ b/app/views/data_lists/new.html.erb
@@ -1,12 +1,5 @@
 <h1>New data_list</h1>
-<strong>Instructions</strong>
 
-
-<ol>
-	<li>Select a name for your list</li>
-	<li>Enter your list of series mnemonics, one per line, no commas</li>
-	<li>Enter in the year you would like your data to begin (can support different date ranges later, but for now, just a single year value in the start year field)</li>
-</ol>
 <%= render 'form' %>
 
 <%= link_to 'Back', data_lists_path %>


### PR DESCRIPTION
Make it easier to create data lists attached to a category by putting creation link in the category edit screen. Automagically links the new data list to its category.

Limited access to the selector for setting the owner of a data list to the `admin` user role, just because it seemed appropriate and not sure why we didn't do this originally. Found a bit of a bug in the setting of ownership that I'll put another story in for.

Also did a little cleanup just because :=)
