### PR TITLE
Early partial: Change reload BLS series task to use current recursive method (UA-897)

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -867,14 +867,14 @@ class Series < ActiveRecord::Base
   
   def Series.get_all_series_from_website(url_string)
     series_from_website = (DataSource.where("universe = 'UHERO' AND eval LIKE '%#{url_string}%'").all.map {|ds| ds.series}).uniq
-    all_series_from_website = series_from_website.map {|s| s.name }
+    series_names = series_from_website.map {|s| s.name }
 
     series_from_website.each do |s|
-      puts s.name
-      all_series_from_website.concat(s.recursive_dependents)
+      logger.debug { s.name }
+      series_names.concat(s.recursive_dependents)
     end
 
-    return Series.where name: all_series_from_website.uniq
+    return Series.where name: series_names.uniq
   end
   
   #currently runs in 3 hrs (for all series..if concurrent series could go first, that might be nice)

--- a/lib/series_relationship.rb
+++ b/lib/series_relationship.rb
@@ -123,19 +123,15 @@ module SeriesRelationship
     results
   end
   
-  def Series.find_first_order_circular
+  def Series.find_first_order_circular(series_set = Series.get_all_uhero)
     circular_series = []
-    Series.get_all_uhero.each do |series|
-      #puts series.name
+    series_set.each do |series|
       fod = series.first_order_dependencies
       fod.each do |dependent_series|
         begin
           circular_series.push(dependent_series) unless dependent_series.ts.first_order_dependencies.index(series.name).nil?
         rescue
-          puts 'THIS BROKE'
-          puts dependent_series
-          puts series.name
-          puts series.id
+          logger.error { "THIS BROKE: #{dependent_series}, #{series.name} (#{series.id})" }
         end
       end
     end

--- a/lib/series_relationship.rb
+++ b/lib/series_relationship.rb
@@ -62,24 +62,6 @@ module SeriesRelationship
     self.data_sources.count
   end
   
-  def Series.update_sources_in_use
-    s = Series.all
-    s.each do |series|
-      series.clean_data_sources if series.data_sources.count > 1
-    end
-    return 1
-  end
-      
-  def open_dependencies(refreshed_list)
-    od = []
-    self.new_dependencies.each do |dep|
-      if refreshed_list.index(dep).nil?
-        od.push(dep)
-      end
-    end
-    od
-  end
-  
   def recursive_dependents(already_seen = [])
     return [] unless already_seen.index(self.name).nil?
     dependent_names = self.new_dependents
@@ -147,10 +129,6 @@ module SeriesRelationship
       puts "#{ppd.id} : #{ppd.eval}"
     end
     circular_series
-  end
-  
-  def Series.print_prioritization_info
-    Series.where('aremos_missing = 0 AND ABS(aremos_diff) >= 10').order('ABS(aremos_diff) DESC').each {|s| puts "#{s.id} - #{s.name}: #{s.new_dependents.count} / #{s.new_dependencies.count} : #{s.aremos_diff}" if s.new_dependents.count > 0 }
   end
   
   def Series.print_multi_sources

--- a/lib/tasks/source_map.rake
+++ b/lib/tasks/source_map.rake
@@ -97,7 +97,7 @@ task :reload_bls_series_only => :environment do
   t = Time.now
   #could also hard code this...
   bls_series = Series.get_all_series_from_website('load_from_bls')
-  Series.run_all_dependencies(bls_series.map { |s| s.name }, {}, [], [])
+  Series.reload_by_dependency_depth bls_series
   CSV.open('public/rake_time.csv', 'a') {|csv| csv << ['bls series dependency check and load', '%.2f' % (Time.now - t) , t.to_s, Time.now.to_s] }
 end
 


### PR DESCRIPTION
This is not the completion of corresponding JIRA story, but I started putting some changes in this branch as I investigated, and might as well merge them. It's mostly changing a var name, changing puts to logger, and getting rid of some abandoned methods I happened to find. The one significant thing is to change the `:reload_bls_series_only` rake task from the legacy dependency reload to the current, `reload_by_dependency_depth`.

I'll leave the branch around and use it later to finish the work mentioned in the story.