### PR TITLE
Rework quarantine logic (UA-898)

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -8,4 +8,7 @@ class HelpController < ApplicationController
 
   def data_sources
   end
+
+  def quarantine
+  end
 end

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -140,7 +140,7 @@ class DataPoint < ActiveRecord::Base
   end
 
   def DataPoint.update_public_data_points(universe = 'UHERO', series = nil)
-    dont_unpublish = FeatureToggle.is_set('dont_unpublish_quarantined', universe, false)
+    dont_unpublish = FeatureToggle.is_set('dont_unpublish_quarantined', universe)
     if series && series.quarantined?
       return true if dont_unpublish
 

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -61,12 +61,11 @@ class DataPoint < ActiveRecord::Base
     end
     series = self.series
 
-    auto_quarantine_toggle = FeatureToggle.where(universe: self.universe, name: 'auto_quarantine').first || FeatureToggle.new(status: true)
-    if auto_quarantine_toggle.status && (Date.today - 2.years > self.date) && !series.quarantined && !series.restricted
-      series.update! quarantined: true
+    auto_quarantine = FeatureToggle.get_toggle('auto_quarantine', universe) rescue true
+    if auto_quarantine && (Date.today - 2.years > self.date) && !series.quarantined && !series.restricted
+      series.update! quarantined: true, restricted: true
     end
     false
-    #self.value == value
   end
   
   def delete

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -140,13 +140,13 @@ class DataPoint < ActiveRecord::Base
   end
 
   def DataPoint.update_public_data_points(universe = 'UHERO', series = nil)
-    remove_quarantine = FeatureToggle.is_set('remove_quarantine_from_public', universe)
+    remove_quarantine = FeatureToggle.is_set('remove_quarantine_from_public', universe, true)
     if series && series.quarantined?
       return true unless remove_quarantine
 
       begin
         stmt = ActiveRecord::Base.connection.raw_connection.prepare(<<~SQL)
-         delete from public_data_points where series_id = ?
+          delete from public_data_points where series_id = ?
         SQL
         stmt.execute(series.id)
         stmt.close

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -62,8 +62,8 @@ class DataPoint < ActiveRecord::Base
     series = self.series
 
     auto_quarantine = FeatureToggle.is_set('auto_quarantine', universe) rescue true
-    if auto_quarantine && (Date.today - 2.years > self.date) && !series.quarantined && !series.restricted
-      series.update! quarantined: true, restricted: true
+    if auto_quarantine && (Date.today - 2.years > self.date) && !series.quarantined? && !series.restricted?
+      series.add_to_quarantine(false)
     end
     false
   end

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -61,7 +61,7 @@ class DataPoint < ActiveRecord::Base
     end
     series = self.series
 
-    auto_quarantine = FeatureToggle.is_set('auto_quarantine', universe) rescue true
+    auto_quarantine = FeatureToggle.is_set('auto_quarantine', universe, true)
     if auto_quarantine && (Date.today - 2.years > self.date) && !series.quarantined? && !series.restricted?
       series.add_to_quarantine(false)
     end
@@ -140,7 +140,7 @@ class DataPoint < ActiveRecord::Base
   end
 
   def DataPoint.update_public_data_points(universe = 'UHERO', series = nil)
-    dont_unpublish = FeatureToggle.is_set('dont_unpublish_quarantined', universe) rescue false
+    dont_unpublish = FeatureToggle.is_set('dont_unpublish_quarantined', universe, false)
     if series && series.quarantined?
       return true if dont_unpublish
 

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -189,7 +189,7 @@ class DataPoint < ActiveRecord::Base
         left join data_points d on d.series_id = p.series_id and d.date = p.date and d.current
       where p.universe = ?
       and( d.created_at is null  /* dp no longer exists in data_points */
-           #{ dont_unpublish ? ') ' : 'or s.quarantined) '}
+           #{'or s.quarantined' unless dont_unpublish} )
       #{' and s.id = ? ' if series} ;
     SQL
     begin

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -61,7 +61,7 @@ class DataPoint < ActiveRecord::Base
     end
     series = self.series
 
-    auto_quarantine = FeatureToggle.is_set('auto_quarantine', universe, true)
+    auto_quarantine = FeatureToggle.is_set('auto_quarantine', true, series.universe)
     if auto_quarantine && (Date.today - 2.years > self.date) && !series.quarantined? && !series.restricted?
       series.add_to_quarantine(false)
     end
@@ -140,7 +140,7 @@ class DataPoint < ActiveRecord::Base
   end
 
   def DataPoint.update_public_data_points(universe = 'UHERO', series = nil)
-    remove_quarantine = FeatureToggle.is_set('remove_quarantine_from_public', universe, true)
+    remove_quarantine = FeatureToggle.is_set('remove_quarantined_from_public', false, universe)
     if series && series.quarantined?
       return true unless remove_quarantine
 

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -61,7 +61,7 @@ class DataPoint < ActiveRecord::Base
     end
     series = self.series
 
-    auto_quarantine = FeatureToggle.get('auto_quarantine', universe) rescue true
+    auto_quarantine = FeatureToggle.is_set('auto_quarantine', universe) rescue true
     if auto_quarantine && (Date.today - 2.years > self.date) && !series.quarantined && !series.restricted
       series.update! quarantined: true, restricted: true
     end
@@ -141,7 +141,8 @@ class DataPoint < ActiveRecord::Base
 
   def DataPoint.update_public_data_points(universe = 'UHERO', series = nil)
     if series && series.quarantined?
-      return true if FeatureToggle.get('dont_unpublish_quarantine', universe) rescue false
+      return true if FeatureToggle.is_set('dont_unpublish_quarantine', universe) rescue false
+
       quarantine_query = <<~SQL
          delete from public_data_points where series_id = ?
       SQL

--- a/app/models/feature_toggle.rb
+++ b/app/models/feature_toggle.rb
@@ -4,4 +4,7 @@ class FeatureToggle < ActiveRecord::Base
     FeatureToggle.where(%q{feature_toggles.universe = 'UHERO'})
   end
 
+  def FeatureToggle.get_toggle(name, universe = 'UHERO')
+    FeatureToggle.where(name: name, universe: universe).first.status ## will raise exception on non-exist
+  end
 end

--- a/app/models/feature_toggle.rb
+++ b/app/models/feature_toggle.rb
@@ -4,7 +4,7 @@ class FeatureToggle < ActiveRecord::Base
     FeatureToggle.where(%q{feature_toggles.universe = 'UHERO'})
   end
 
-  def FeatureToggle.get(name, universe = 'UHERO')
-    FeatureToggle.where(name: name, universe: universe).first.status ## will raise exception on non-exist
+  def FeatureToggle.is_set(name, universe = 'UHERO')
+    FeatureToggle.find_by(name: name, universe: universe).status  ## raises exception on non-exist
   end
 end

--- a/app/models/feature_toggle.rb
+++ b/app/models/feature_toggle.rb
@@ -4,7 +4,10 @@ class FeatureToggle < ActiveRecord::Base
     FeatureToggle.where(%q{feature_toggles.universe = 'UHERO'})
   end
 
-  def FeatureToggle.is_set(name, universe = 'UHERO', default = false)
-    FeatureToggle.find_by(name: name, universe: universe).status rescue default
+  def FeatureToggle.is_set(name, default, universe = 'UHERO')
+    toggle = FeatureToggle.find_by(name: name, universe: universe)
+    return toggle.status if toggle
+    logger.debug { "Feature toggle #{name} not existent in universe #{universe}" }
+    default
   end
 end

--- a/app/models/feature_toggle.rb
+++ b/app/models/feature_toggle.rb
@@ -4,7 +4,7 @@ class FeatureToggle < ActiveRecord::Base
     FeatureToggle.where(%q{feature_toggles.universe = 'UHERO'})
   end
 
-  def FeatureToggle.get_toggle(name, universe = 'UHERO')
+  def FeatureToggle.get(name, universe = 'UHERO')
     FeatureToggle.where(name: name, universe: universe).first.status ## will raise exception on non-exist
   end
 end

--- a/app/models/feature_toggle.rb
+++ b/app/models/feature_toggle.rb
@@ -4,7 +4,7 @@ class FeatureToggle < ActiveRecord::Base
     FeatureToggle.where(%q{feature_toggles.universe = 'UHERO'})
   end
 
-  def FeatureToggle.is_set(name, universe = 'UHERO')
-    FeatureToggle.find_by(name: name, universe: universe).status  ## raises exception on non-exist
+  def FeatureToggle.is_set(name, universe = 'UHERO', default = false)
+    FeatureToggle.find_by(name: name, universe: universe).status rescue default
   end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -357,7 +357,7 @@ class Series < ActiveRecord::Base
 
   def add_to_quarantine
     update = { quarantined: true }
-    if FeatureToggle.get_toggle('restrict_quarantine', universe) rescue false
+    if FeatureToggle.get('restrict_quarantine', universe) rescue false
       update.merge!(:restricted, true)
     end
     self.update! update

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -358,7 +358,7 @@ class Series < ActiveRecord::Base
   def add_to_quarantine(run_update = true)
     raise 'Cannot add restricted series to quarantine' if restricted?
     update = { quarantined: true }
-    if FeatureToggle.is_set('restrict_quarantine',universe, false)
+    if FeatureToggle.is_set('restrict_quarantine',universe)
       update.merge!(restricted: true)
     end
     self.update! update
@@ -368,7 +368,7 @@ class Series < ActiveRecord::Base
   def remove_from_quarantine(run_update = true)
     raise 'Trying to remove unquarantined series from quarantine' unless quarantined?
     update = { quarantined: false }
-    if FeatureToggle.is_set('restrict_quarantine', universe, false)
+    if FeatureToggle.is_set('restrict_quarantine', universe)
       update.merge!(restricted: false)
     end
     self.update! update
@@ -377,7 +377,7 @@ class Series < ActiveRecord::Base
 
   def Series.empty_quarantine
     update = { quarantined: false }
-    if FeatureToggle.is_set('restrict_quarantine', universe, false)
+    if FeatureToggle.is_set('restrict_quarantine', universe)
       update.merge!(restricted: false)
     end
     Series.get_all_uhero.where(quarantined: true).update_all update

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -355,7 +355,6 @@ class Series < ActiveRecord::Base
   end
 
   def add_to_quarantine(run_update = true)
-    raise 'Trying to quarantine an already quarantined series' if quarantined?
     self.update! quarantined: true
     DataPoint.update_public_data_points(universe.sub(/^UHERO.*/, 'UHERO'), self) if run_update
   end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -357,15 +357,19 @@ class Series < ActiveRecord::Base
 
   def add_to_quarantine
     update = { quarantined: true }
-    if FeatureToggle.get('restrict_quarantine', universe) rescue false
-      update.merge!(:restricted, true)
+    if FeatureToggle.is_set('restrict_quarantine', universe) rescue false
+      update.merge!(restricted: true)
     end
     self.update! update
     DataPoint.update_public_data_points(universe, self)
   end
 
   def remove_from_quarantine
-    self.update! quarantined: false, restricted: false
+    update = { quarantined: false }
+    if FeatureToggle.is_set('restrict_quarantine', universe) rescue false
+      update.merge!(restricted: false)
+    end
+    self.update! update
     DataPoint.update_public_data_points(universe, self)
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -355,22 +355,24 @@ class Series < ActiveRecord::Base
     []
   end
 
-  def add_to_quarantine
+  def add_to_quarantine(run_update = true)
+    raise 'Cannot add restricted series to quarantine' if restricted?
     update = { quarantined: true }
     if FeatureToggle.is_set('restrict_quarantine', universe) rescue false
       update.merge!(restricted: true)
     end
     self.update! update
-    DataPoint.update_public_data_points(universe, self)
+    DataPoint.update_public_data_points(universe, self) if run_update
   end
 
-  def remove_from_quarantine
+  def remove_from_quarantine(run_update = true)
+    raise 'Trying to remove unquarantined series from quarantine' unless quarantined?
     update = { quarantined: false }
     if FeatureToggle.is_set('restrict_quarantine', universe) rescue false
       update.merge!(restricted: false)
     end
     self.update! update
-    DataPoint.update_public_data_points(universe, self)
+    DataPoint.update_public_data_points(universe, self) if run_update
   end
 
   def Series.empty_quarantine

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -342,7 +342,6 @@ class Series < ActiveRecord::Base
     observation_dates = observation_dates - current_data_points.map {|dp| dp.date}
     observation_dates.each do |date|
       data_points.create(
-        universe: universe,
         :date => date,
         :value => data[date],
         :created_at => Time.now,

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -1,1 +1,2 @@
-<%= link_to 'Data Sources', controller: 'help', action: 'data_sources' %>
+<p><%= link_to 'Data Sources', controller: 'help', action: 'data_sources' %></p>
+<p><%= link_to 'Quarantine', controller: 'help', action: 'quarantine' %></p>

--- a/app/views/help/quarantine.html.erb
+++ b/app/views/help/quarantine.html.erb
@@ -1,0 +1,15 @@
+<h2>Series Quarantine</h2>
+
+Series may be added to the quarantine, and removed from the quarantine, manually using the links on the left side of the Udaman series show page.
+<p></p>
+Series can additionally be added to the quarantine by Udaman automatically if <strong>all</strong> of the following conditions hold:
+<ol>
+  <li>The feature toggle <code>auto_quarantine</code> for the corresponding universe is NOT set to false (default is <strong>true</strong>)</li>
+  <li>The series is not restricted</li>
+  <li>A data update attempts to change the series value for a date that is more than two years in the past</li>
+</ol>
+
+There are two other feature toggle settings that are related to the quarantine:
+<p><strong>filter_by_quarantine</strong> - The data portal will hide data from any series that are quarantined (default <strong>false</strong>).</p>
+<p><strong>remove_quarantined_from_public</strong> - When true, series data will be removed from the set of published data; when false,
+  any published data are left as-is (not updated) until the series is removed from quarantine (default <strong>false</strong>)</p>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -57,14 +57,12 @@ google.visualization.events.addListener(chart, 'select', function() {
     <tr><td>Source Link</td><td><%= (@series.source_link.nil? || @series.source_link.empty?) ? (@series.source.link unless @series.source.nil?) : @series.source_link %></td></tr>
     <tr><td>Source Details</td><td><%= @series.source_detail.description unless @series.source_detail.nil? %></td></tr>
     <tr><td>Restricted</td><td><%= @series.restricted.to_s %></td></tr>
-    <% unless @series.restricted %>
       <tr><td>Quarantined</td><td><%= @series.quarantined.to_s %>
           <span id="series_controls">
             <%= link_to('(add)', action: :add_to_quarantine, id: @series) unless @series.quarantined %>
             <%= link_to('(remove)', action: :remove_from_quarantine, id: @series) if @series.quarantined %>
          </span>
       </td></tr>
-    <% end %>
   </table>
 
 	<div id="navigation">

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -59,7 +59,7 @@ google.visualization.events.addListener(chart, 'select', function() {
     <tr><td>Restricted</td><td><%= @series.restricted.to_s %></td></tr>
       <tr><td>Quarantined</td><td><%= @series.quarantined.to_s %>
           <span id="series_controls">
-            <%= link_to('(add)', action: :add_to_quarantine, id: @series) unless @series.quarantined %>
+            <%= link_to('(add)', action: :add_to_quarantine, id: @series) unless @series.quarantined || @series.restricted %>
             <%= link_to('(remove)', action: :remove_from_quarantine, id: @series) if @series.quarantined %>
          </span>
       </td></tr>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -57,12 +57,14 @@ google.visualization.events.addListener(chart, 'select', function() {
     <tr><td>Source Link</td><td><%= (@series.source_link.nil? || @series.source_link.empty?) ? (@series.source.link unless @series.source.nil?) : @series.source_link %></td></tr>
     <tr><td>Source Details</td><td><%= @series.source_detail.description unless @series.source_detail.nil? %></td></tr>
     <tr><td>Restricted</td><td><%= @series.restricted.to_s %></td></tr>
+    <% unless @series.restricted %>
       <tr><td>Quarantined</td><td><%= @series.quarantined.to_s %>
           <span id="series_controls">
-            <%= link_to('(add)', action: :add_to_quarantine, id: @series) unless @series.quarantined || @series.restricted %>
+            <%= link_to('(add)', action: :add_to_quarantine, id: @series) unless @series.quarantined %>
             <%= link_to('(remove)', action: :remove_from_quarantine, id: @series) if @series.quarantined %>
          </span>
       </td></tr>
+    <% end %>
   </table>
 
 	<div id="navigation">


### PR DESCRIPTION
Improved the model API for feature toggles (I think).

Main functional change is introduction of new feature toggle `remove_quarantine_from_public`, which means to proactively delete any data points found in the public table for series which have been quarantined _since_ those points were inserted. Default value hardwired in code for this is `true`.

Test by picking a series and flipping its quarantine flag, while flipping the new feature toggle and running both `DataPoint.update_public_data_points` and `DataPoint.update_public_data_points('UHERO', Series.find(__id__))`.