### PR TITLE
Hiding/uhiding categories should mask/unmask (UA-899)

### DIFF
--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -23,12 +23,4 @@ $(function() {
             $('.category_non_leaf').each(function() { $(this).html( $(this).html().replace('-minus-', '-plus-') ); });
         }
     });
-    $("a[data-remote][data-toggle]").on("ajax:success", function(e, data, status, xhr) {
-        $(this).siblings("span.hidden_cat_label").toggle();
-        if ($(this).html() === 'Unhide') {
-            $(this).html('Hide');
-            return;
-        }
-        $(this).html('Unhide');
-    });
 });

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -9,7 +9,6 @@
 }
 
 .masked_category {
-  background-color: lightgrey;
   font-weight:bold;
   text-decoration:line-through;
 }

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -2,11 +2,11 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.hidden_cat {
+.hidden_category {
   color: red;
 }
 
-.masked_cat {
+.masked_category {
   background-color: lightgrey;
 }
 

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -2,8 +2,12 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.hidden_cat_label {
+.hidden_cat {
   color: red;
+}
+
+.masked_cat {
+  background-color: lightgrey;
 }
 
 .category_non_leaf {

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -3,11 +3,15 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .hidden_category {
-  color: red;
+  color: indianred;
+  font-weight:bold;
+  text-decoration:line-through;
 }
 
 .masked_category {
   background-color: lightgrey;
+  font-weight:bold;
+  text-decoration:line-through;
 }
 
 .category_non_leaf {

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,7 +2,7 @@ class CategoriesController < ApplicationController
   include Authorization
   
   before_action :check_authorization
-  before_action :set_category, only: [:show, :edit, :update, :destroy, :up, :down, :toggle_hidden, :unhide_tree, :add_child]
+  before_action :set_category, only: [:show, :edit, :update, :destroy, :up, :down, :toggle_hidden, :add_child]
 
   # GET /categories
   def index
@@ -55,10 +55,6 @@ class CategoriesController < ApplicationController
       format.js { render nothing: true, status: 200 }
     end
     @category.hidden? ? @category.unhide : @category.hide
-  end
-
-  def unhide_tree
-    @category.unhide_tree
   end
 
   def add_child

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -54,7 +54,7 @@ class CategoriesController < ApplicationController
     respond_to do |format|
       format.js { render nothing: true, status: 200 }
     end
-    @category.hidden? ? @category.hide : @category.unhide
+    @category.hidden? ? @category.unhide : @category.hide
   end
 
   def add_child

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -54,7 +54,7 @@ class CategoriesController < ApplicationController
     respond_to do |format|
       format.js { render nothing: true, status: 200 }
     end
-    @category.update_attributes(:hidden => !@category.hidden)
+    @category.hidden? ? @category.hide : @category.unhide
   end
 
   def add_child

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,7 +2,7 @@ class CategoriesController < ApplicationController
   include Authorization
   
   before_action :check_authorization
-  before_action :set_category, only: [:show, :edit, :update, :destroy, :up, :down, :toggle_hidden, :add_child]
+  before_action :set_category, only: [:show, :edit, :update, :destroy, :up, :down, :toggle_hidden, :unhide_tree, :add_child]
 
   # GET /categories
   def index
@@ -55,6 +55,10 @@ class CategoriesController < ApplicationController
       format.js { render nothing: true, status: 200 }
     end
     @category.hidden? ? @category.unhide : @category.hide
+  end
+
+  def unhide_tree
+    @category.unhide_tree
   end
 
   def add_child

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -51,10 +51,8 @@ class CategoriesController < ApplicationController
   end
 
   def toggle_hidden
-    respond_to do |format|
-      format.js { render nothing: true, status: 200 }
-    end
     @category.hidden? ? @category.unhide : @category.hide
+    redirect_to categories_url
   end
 
   def add_child

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -47,6 +47,9 @@ private
     if current_user.dev_user?
       if leaf.hidden
         menu.push link_to('Unhide', {:controller => :categories, action: :toggle_hidden, :id => leaf}, remote: true, data: {toggle: 1})
+        unless leaf.get_children.empty?
+          menu.push link_to('UnhideTree', {:controller => :categories, action: :unhide_tree, :id => leaf}, remote: true, data: {toggle: 1})
+        end
       else
         menu.push link_to('Hide', {:controller => :categories, action: :toggle_hidden, :id => leaf}, remote: true, data: {toggle: 1})
       end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -28,11 +28,11 @@ private
   def show_list_item(leaf, first, last)
     display_class =
         case
-          when leaf.hidden? then 'hidden_category'
-          when leaf.masked > 0 then 'masked_category'
+          when leaf.hidden? then 'hidden_category '
+          when leaf.masked? then 'masked_category '
           else ''
         end
-    span_class = display_class + (leaf.is_childless? ? ' category_leaf' : ' category_non_leaf')
+    span_class = display_class + (leaf.is_childless? ? 'category_leaf' : 'category_non_leaf')
     icon_type = leaf.is_childless? ? 'fa-square' : 'fa-plus-square'
     data_list_section =
         case
@@ -51,10 +51,9 @@ private
       menu.push link_to('Edit', edit_category_path(leaf))
     end
     if current_user.dev_user?
-      if leaf.hidden
-        menu.push link_to('Unhide', {:controller => :categories, action: :toggle_hidden, :id => leaf}, remote: true, data: {toggle: 1})
-      else
-        menu.push link_to('Hide', {:controller => :categories, action: :toggle_hidden, :id => leaf}, remote: true, data: {toggle: 1})
+      unless leaf.is_root?
+        hide_op = leaf.hidden? ? 'Unhide' : 'Hide'
+        menu.push link_to(hide_op, {:controller => :categories, action: :toggle_hidden, :id => leaf}, remote: true, data: {toggle: 1})
       end
       menu.push link_to('Destroy', leaf, method: :delete, data: { confirm: "Destroy #{leaf.name}: Are you sure??" })
     end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -47,9 +47,6 @@ private
     if current_user.dev_user?
       if leaf.hidden
         menu.push link_to('Unhide', {:controller => :categories, action: :toggle_hidden, :id => leaf}, remote: true, data: {toggle: 1})
-        unless leaf.get_children.empty?
-          menu.push link_to('UnhideTree', {:controller => :categories, action: :unhide_tree, :id => leaf}, remote: true, data: {toggle: 1})
-        end
       else
         menu.push link_to('Hide', {:controller => :categories, action: :toggle_hidden, :id => leaf}, remote: true, data: {toggle: 1})
       end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,12 +1,12 @@
 module CategoriesHelper
   def show_table(root, first, last)
-    list_item = show_list_item(root, first, last)
     display_class =
         case
-          when list_item.hidden? then 'hidden_cat'
-          when list_item.masked > 0 then 'masked_cat'
+          when root.hidden then 'hidden_cat'
+          when root.masked > 0 then 'masked_cat'
           else nil
         end
+    list_item = show_list_item(root, first, last)
     return "<li class='#{display_class}'>#{list_item}</li>\n" if root.is_childless?
 
     categories = (root.children.to_a).sort_by!{ |cat| cat.list_order }

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,13 +1,7 @@
 module CategoriesHelper
   def show_table(root, first, last)
-    display_class =
-        case
-          when root.hidden then 'hidden_cat'
-          when root.masked > 0 then 'masked_cat'
-          else nil
-        end
     list_item = show_list_item(root, first, last)
-    return "<li class='#{display_class}'>#{list_item}</li>\n" if root.is_childless?
+    return "<li>#{list_item}</li>\n" if root.is_childless?
 
     categories = (root.children.to_a).sort_by!{ |cat| cat.list_order }
     category_strings = []
@@ -16,7 +10,7 @@ module CategoriesHelper
     }
 
     <<~HTML
-    <li><span class="#{display_class}">#{list_item}</span>
+    <li>#{list_item}
         <ul class="collapsible" style="display:none;list-style:none;">
           #{category_strings.join("\n")}
         </ul>
@@ -32,7 +26,13 @@ module CategoriesHelper
 
 private
   def show_list_item(leaf, first, last)
-    span_class = leaf.is_childless? ? 'category_leaf' : 'category_non_leaf'
+    display_class =
+        case
+          when leaf.hidden? then 'hidden_category'
+          when leaf.masked > 0 then 'masked_category'
+          else ''
+        end
+    span_class = display_class + (leaf.is_childless? ? ' category_leaf' : ' category_non_leaf')
     icon_type = leaf.is_childless? ? 'fa-square' : 'fa-plus-square'
     data_list_section =
         case
@@ -58,8 +58,6 @@ private
       end
       menu.push link_to('Destroy', leaf, method: :delete, data: { confirm: "Destroy #{leaf.name}: Are you sure??" })
     end
-    display = leaf.hidden ? '' : 'display:none;'
-    menu.push "<span class='hidden_cat' style='#{display}'>***** HIDDEN *****</span>"
     name_part + ' ' + menu.join(' - ')
   end
 

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,7 +1,13 @@
 module CategoriesHelper
   def show_table(root, first, last)
     list_item = show_list_item(root, first, last)
-    return "<li>#{list_item}</li>\n" if root.is_childless?
+    display_class =
+        case
+          when list_item.hidden? then 'hidden_cat'
+          when list_item.masked > 0 then 'masked_cat'
+          else nil
+        end
+    return "<li class='#{display_class}'>#{list_item}</li>\n" if root.is_childless?
 
     categories = (root.children.to_a).sort_by!{ |cat| cat.list_order }
     category_strings = []
@@ -10,7 +16,7 @@ module CategoriesHelper
     }
 
     <<~HTML
-    <li>#{list_item}
+    <li><span class="#{display_class}">#{list_item}</span>
         <ul class="collapsible" style="display:none;list-style:none;">
           #{category_strings.join("\n")}
         </ul>
@@ -53,7 +59,7 @@ private
       menu.push link_to('Destroy', leaf, method: :delete, data: { confirm: "Destroy #{leaf.name}: Are you sure??" })
     end
     display = leaf.hidden ? '' : 'display:none;'
-    menu.push "<span class='hidden_cat_label' style='#{display}'>***** HIDDEN *****</span>"
+    menu.push "<span class='hidden_cat' style='#{display}'>***** HIDDEN *****</span>"
     name_part + ' ' + menu.join(' - ')
   end
 

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -53,7 +53,7 @@ private
     if current_user.dev_user?
       unless leaf.is_root?
         hide_op = leaf.hidden? ? 'Unhide' : 'Hide'
-        menu.push link_to(hide_op, {:controller => :categories, action: :toggle_hidden, :id => leaf}, remote: true, data: {toggle: 1})
+        menu.push link_to(hide_op, {:controller => :categories, action: :toggle_hidden, :id => leaf})
       end
       menu.push link_to('Destroy', leaf, method: :delete, data: { confirm: "Destroy #{leaf.name}: Are you sure??" })
     end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -19,7 +19,7 @@ module CategoriesHelper
   end
 
   def category_path_breadcrumbs(category, extra_sep = false)
-    path = category.get_path_from_root
+    path = category.ancestors.map{|a| a.name }
     path.push '' if extra_sep
     path.join(' > ').html_safe
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,13 +4,23 @@ class Category < ActiveRecord::Base
   belongs_to :default_geo, class_name: 'Geography'  ## in other words this model's `default_geo_id` is a Geography.id
   before_save :set_list_order
 
-  def toggle_tree_masked(value)
-    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each{|c| c.update_attributes masked: value }
+  def toggle_tree_masked
+    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each{|c| c.update_attributes masked: c.masked + 1 }
+  end
+
+  def toggle_tree_unmasked
+    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each do |c|
+      if c.masked == 0
+        logger.error { "toggle_tree_unmasked: category #{name}: Decrementing zero counter" }
+      else
+        c.update_attributes masked: c.masked - 1
+      end
+    end
   end
 
   def hide
     self.update_attributes hidden: true
-    toggle_tree_masked true
+    toggle_tree_masked
   end
 
   def unhide

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,16 +5,13 @@ class Category < ActiveRecord::Base
   before_save :set_list_order
 
   def toggle_tree_masked
-    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each{|c| c.increment! :masked }
+    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each{|c| c.update_attributes(masked: 1) }
   end
 
   def toggle_tree_unmasked
-    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each do |c|
-      if c.masked == 0
-        logger.error { "toggle_tree_unmasked: category #{name}: Decrementing zero counter" }
-      else
-        c.decrement! :masked
-      end
+    get_children.each do |c|
+      c.update_attributes(masked: 0)
+      c.toggle_tree_unmasked unless c.hidden
     end
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -18,10 +18,6 @@ class Category < ActiveRecord::Base
     end
   end
 
-  def is_hidden
-    hidden || masked > 0
-  end
-
   def hide
     self.update_attributes hidden: true
     toggle_tree_masked
@@ -30,15 +26,6 @@ class Category < ActiveRecord::Base
   def unhide
     self.update_attributes hidden: false
     toggle_tree_unmasked
-    return
-    begin
-      ancestors = Category.find(self.ancestry.split(/\//))
-    rescue => e
-      ## we get here most likely because an ancestor id doesn't exist
-      logger.error { e.message }
-      raise e
-    end
-    ancestors.each{|c| c.update_attributes hidden: false }
   end
 
   def get_children

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -22,7 +22,7 @@ class Category < ActiveRecord::Base
 
   def unhide
     self.update_attributes hidden: false
-    toggle_tree_unmasked
+    toggle_tree_unmasked if self.masked == 0
   end
 
   def get_children

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,10 +6,19 @@ class Category < ActiveRecord::Base
 
   def hide
     self.update_attributes hidden: true
+    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each{|c| c.update_attributes hidden: true }
   end
 
   def unhide
     self.update_attributes hidden: false
+    begin
+      ancestors = Category.find(self.ancestry.split(/\//))
+    rescue => e
+      ## we get here most likely because an ancestor id doesn't exist
+      logger.error { e.message }
+      raise
+    end
+    ancestors.each{|c| c.update_attributes hidden: false }
   end
 
   def add_child

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,6 +4,14 @@ class Category < ActiveRecord::Base
   belongs_to :default_geo, class_name: 'Geography'  ## in other words this model's `default_geo_id` is a Geography.id
   before_save :set_list_order
 
+  def hide
+    self.update_attributes hidden: true
+  end
+
+  def unhide
+    self.update_attributes hidden: false
+  end
+
   def add_child
     child_ancestry = ancestry ? "#{ancestry}/#{id}" : id
     max_sib = Category.where(ancestry: child_ancestry).maximum(:list_order)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,18 +4,13 @@ class Category < ActiveRecord::Base
   belongs_to :default_geo, class_name: 'Geography'  ## in other words this model's `default_geo_id` is a Geography.id
   before_save :set_list_order
 
-  def toggle_tree_hidden(value)
-    self.update_attributes hidden: value
-    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each{|c| c.update_attributes hidden: value }
+  def toggle_tree_masked(value)
+    Category.where("ancestry rlike '/#{id}/[0-9]|/#{id}$'").each{|c| c.update_attributes masked: value }
   end
 
   def hide
-    toggle_tree_hidden(true)
-  end
-
-  def unhide_tree
-    toggle_tree_hidden(false)
-    unhide
+    self.update_attributes hidden: true
+    toggle_tree_masked true
   end
 
   def unhide
@@ -28,6 +23,7 @@ class Category < ActiveRecord::Base
       raise e
     end
     ancestors.each{|c| c.update_attributes hidden: false }
+    toggle_tree_masked false
   end
 
   def get_children

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -52,7 +52,8 @@ class Category < ActiveRecord::Base
     Category.create(universe: universe,
                     name: 'XXX New child XXX',
                     ancestry: child_ancestry,
-                    hidden: hidden,
+                    hidden: false,
+                    masked: masked,
                     list_order: max_sib.nil? ? 0 : max_sib + 1)
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -26,23 +26,11 @@ class Category < ActiveRecord::Base
   end
 
   def add_child
-    child_ancestry = ancestry ? "#{ancestry}/#{id}" : id
-    max_sib = Category.where(ancestry: child_ancestry).maximum(:list_order)
-    Category.create(universe: universe,
+    max_sib = children.maximum(:list_order)
+    children.create(universe: universe,
                     name: 'XXX New child XXX',
-                    ancestry: child_ancestry,
-                    hidden: false,
                     masked: masked || hidden,
                     list_order: max_sib.nil? ? 0 : max_sib + 1)
-  end
-
-  def get_path_from_root
-    path = []
-    return path if ancestry.blank?
-    ancestry.split('/').each do |id|
-      path.push Category.find(id).name rescue 'Unknown category'
-    end
-    path
   end
 
   def set_list_order

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -10,3 +10,4 @@
       <%= show_table(@category_roots[i], i == 0, i + 1 == @category_roots.length).html_safe %>
   <% end %>
 </ul>
+Categories can be <span class="hidden_category"><strong>hidden</strong></span>, or <span class="masked_category"><strong>masked</strong> by a hidden parent</span>.

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,7 +1,7 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Listing Categories</h1>
-
+Categories can be <span class="hidden_category">hidden</span>, or <span class="masked_category">masked</span> by a hidden ancestor.
 <p>
 <span id="toggle_all" style="cursor:pointer;cursor:hand;">Expand all</span>
 </p>
@@ -10,4 +10,3 @@
       <%= show_table(@category_roots[i], i == 0, i + 1 == @category_roots.length).html_safe %>
   <% end %>
 </ul>
-Categories can be <span class="hidden_category"><strong>hidden</strong></span>, or <span class="masked_category"><strong>masked</strong> by a hidden parent</span>.

--- a/db/migrate/220170413025739_add_masked_to_categories.rb
+++ b/db/migrate/220170413025739_add_masked_to_categories.rb
@@ -1,0 +1,5 @@
+class AddMaskedToCategories < ActiveRecord::Migration
+  def change
+    add_column :categories, :masked, :boolean, null: false, default: false, after: :hidden
+  end
+end

--- a/db/migrate/220170413025739_add_masked_to_categories.rb
+++ b/db/migrate/220170413025739_add_masked_to_categories.rb
@@ -1,5 +1,5 @@
 class AddMaskedToCategories < ActiveRecord::Migration
   def change
-    add_column :categories, :masked, :integer, null: false, default: 0, after: :hidden
+    add_column :categories, :masked, :boolean, null: false, default: false, after: :hidden
   end
 end

--- a/db/migrate/220170413025739_add_masked_to_categories.rb
+++ b/db/migrate/220170413025739_add_masked_to_categories.rb
@@ -1,5 +1,5 @@
 class AddMaskedToCategories < ActiveRecord::Migration
   def change
-    add_column :categories, :masked, :boolean, null: false, default: false, after: :hidden
+    add_column :categories, :masked, :integer, null: false, default: 0, after: :hidden
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 220170413025738) do
+ActiveRecord::Schema.define(version: 220170413025739) do
 
   create_table "api_applications", force: :cascade do |t|
     t.string   "universe",        limit: 5,   default: "UHERO", null: false
@@ -24,15 +24,6 @@ ActiveRecord::Schema.define(version: 220170413025738) do
   end
 
   add_index "api_applications", ["universe", "name"], name: "index_api_applications_on_universe_and_name", unique: true, using: :btree
-
-  create_table "api_users", force: :cascade do |t|
-    t.string   "key",        limit: 255
-    t.string   "email",      limit: 255
-    t.string   "name",       limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "hostname",   limit: 255
-  end
 
   create_table "aremos_series", force: :cascade do |t|
     t.string   "name",               limit: 255
@@ -67,6 +58,7 @@ ActiveRecord::Schema.define(version: 220170413025738) do
     t.datetime "created_at",                                   null: false
     t.datetime "updated_at",                                   null: false
     t.boolean  "hidden",                     default: false
+    t.boolean  "masked",                     default: false,   null: false
     t.boolean  "header",                     default: false
     t.integer  "list_order",     limit: 4
     t.integer  "order",          limit: 4


### PR DESCRIPTION
Hiding a node in the category tree causes descendant nodes to be masked (i.e. implicitly rather than explicitly hidden). UI for hidden nodes changed from `***** HIDDEN *****` label to displaying the category name in `indianred` color with strikethrough. Masked nodes have only strikethrough.

Clicking hide/unhide now reloads the page, where it only updated UI via AJAX before. Hide/unhide links removed from data portal root categories (unneeded and potential source of trouble).

There are a few unrelated changes mixed in here where I changed to using the ancestry module for things that it should be doing, where I had coded it by hand before.