### PR TITLE
Fix NTA category ordering problem (UA-912)

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -25,12 +25,20 @@ class Category < ActiveRecord::Base
     toggle_tree_unmasked unless self.masked
   end
 
-  def add_child
+  def add_child(params = {})
     max_sib = children.maximum(:list_order)
-    children.create(universe: universe,
-                    name: 'XXX New child XXX',
-                    masked: masked || hidden,
-                    list_order: max_sib.nil? ? 0 : max_sib + 1)
+    defaults = {
+        universe: universe,
+        name: 'XXX New child XXX',
+        masked: masked || hidden,
+        list_order: max_sib.nil? ? 0 : max_sib + 1
+    }
+    children.create(defaults.merge(params))
+  end
+
+  def get_or_add_child(attrs)
+    kids = children.where(attrs)
+    kids.empty? ? add_child(attrs) : kids.first
   end
 
   def set_list_order

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -59,11 +59,6 @@ class Category < ActiveRecord::Base
     end
   end
 
-  def Category.get_or_new_nta(attrs, add_attrs = {})
-    attrs.merge!(universe: 'NTA')
-    Category.find_by(attrs) || Category.create(attrs.merge(add_attrs))
-  end
-
   def Category.get_all(except = nil)
     if except
       Category.where("universe = 'UHERO' AND id != ?", except).order(:name)

--- a/app/models/nta_upload.rb
+++ b/app/models/nta_upload.rb
@@ -119,8 +119,8 @@ class NtaUpload < ActiveRecord::Base
 
       data_list_name = 'NTA_%s' % row[0].to_ascii.strip
       long_name = row[1].to_ascii.strip
-      nav_cat = root_cat.get_or_add_child { name: row[4].to_ascii.strip }
-      category = nav_cat.get_or_add_child { name: long_name,  meta: data_list_name }
+      nav_cat = root_cat.get_or_add_child({ name: row[4].to_ascii.strip })
+      category = nav_cat.get_or_add_child({ name: long_name,  meta: data_list_name })
 
       data_list_name.gsub!(/\W+/, '_')  ## From here down, slugify
 


### PR DESCRIPTION
Converted NTA categories load code from manipulating ancestry stuff by hand to using the API provided by this package. This required a bit of refactoring of the Category model's `add_child` method, recently introduced along with similar changes to UHERO's category management UI. `add_child` sets the `list_order` property, which is what we needed to solve the problem of this story.

But bec of the possibility for introduction of regression to the aforementioned UI, that functionality should be retested. Testing the NTA part of things can be accomplished by having NTA data files as appropriate in testing environment, and running in a rails console `NtaUpload.find(:id).full_load`. No need to wait for it to finish.... when it has created the categories, check them in a db tool against production, and they should be the same (up to resource ids).