### PR TITLE
Reload series function that includes recursive dependencies (UA-929)

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1027,6 +1027,7 @@ class Series < ActiveRecord::Base
   end
 
   def reload_with_dependencies
+    logger.info { "reload_with_dependencies: series #{id} (#{name}): start" }
     result_set = [self.id]
     next_set = [self.id]
     until next_set.empty?
@@ -1041,6 +1042,7 @@ class Series < ActiveRecord::Base
       next_set = new_deps.map(&:id) - result_set
       result_set += next_set
     end
+    logger.info { "reload_with_dependencies: series #{id} (#{name}): ship off to reload_by_dependency_depth" }
     Series.reload_by_dependency_depth Series.where id: result_set
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1032,8 +1032,8 @@ class Series < ActiveRecord::Base
     until next_set.empty?
       logger.debug { "reload_with_dependencies: next_set is #{next_set}" }
       qmarks = next_set.count.times.map{ '?' }.join(',')
-      new_deps = Series.find_by_sql(<<~SQL, next_set)
-        select distinct series_id
+      new_deps = Series.find_by_sql([<<~SQL, next_set])
+        select distinct series_id as id
         from data_sources
           join series s2 on s2.id in (#{qmarks})
         where dependencies like CONCAT('% ', REPLACE(s2.name, '%', '\\%'), '%')

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1022,6 +1022,20 @@ class Series < ActiveRecord::Base
     end
   end
 
+  def reload_with_dependencies(series_name)
+    seen = { series_name => true }
+    next_set = [series_name]
+    until next_set.empty?
+      foo = Series.joins(:data_sources)
+                       .where(name: next_set)
+                       .where(%q{data_sources.dependencies LIKE CONCAT('% ', REPLACE(series.name, '%', '\\%'), '%')})
+                       .pluck(:name)
+      foo -= seen.keys
+      next_set = foo #?
+    end
+    true
+  end
+
   def Series.reload_by_dependency_depth(series_list = Series.get_all_uhero)
     require 'redis'
     redis = Redis.new

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1032,7 +1032,7 @@ class Series < ActiveRecord::Base
     until next_set.empty?
       logger.debug { "reload_with_dependencies: next_set is #{next_set}" }
       qmarks = next_set.count.times.map{ '?' }.join(',')
-      new_deps = Series.find_by_sql([<<~SQL, next_set])
+      new_deps = Series.find_by_sql [<<~SQL, next_set].flatten ## this is so wackt that it must be done this way :(
         select distinct series_id as id
         from data_sources
           join series s2 on s2.id in (#{qmarks})

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1033,7 +1033,10 @@ class Series < ActiveRecord::Base
     until next_set.empty?
       logger.debug { "reload_with_dependencies: next_set is #{next_set}" }
       qmarks = next_set.count.times.map{ '?' }.join(',')
-      new_deps = Series.find_by_sql [<<~SQL, next_set].flatten ## this is so wackt that it must be done this way :(
+      ## So wackt that find_by_sql works this way :( But if it's fixed in Rails 5, remove this comment :)
+      ##   https://apidock.com/rails/ActiveRecord/Querying/find_by_sql (check sample code - method signature shown is wrong!)
+      ##   https://stackoverflow.com/questions/18934542/rails-find-by-sql-and-parameter-for-id/49765762#49765762
+      new_deps = Series.find_by_sql [<<~SQL, next_set].flatten
         select distinct series_id as id
         from data_sources, series
         where series.id in (#{qmarks})

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1033,9 +1033,8 @@ class Series < ActiveRecord::Base
       logger.debug { "reload_with_dependencies: next_set is #{next_set}" }
       qmarks = next_set.count.times.map{ '?' }.join(',')
       new_deps = Series.find_by_sql(<<~SQL, next_set)
-        select distinct s1.id
+        select distinct series_id
         from data_sources
-          join series s1 on data_sources.series_id = s1.id
           join series s2 on s2.id in (#{qmarks})
         where dependencies like CONCAT('% ', REPLACE(s2.name, '%', '\\%'), '%')
       SQL

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1034,14 +1034,14 @@ class Series < ActiveRecord::Base
       qmarks = next_set.count.times.map{ '?' }.join(',')
       new_deps = Series.find_by_sql [<<~SQL, next_set].flatten ## this is so wackt that it must be done this way :(
         select distinct series_id as id
-        from data_sources
-          join series s2 on s2.id in (#{qmarks})
-        where dependencies like CONCAT('% ', REPLACE(s2.name, '%', '\\%'), '%')
+        from data_sources, series
+        where series.id in (#{qmarks})
+        and dependencies like CONCAT('% ', REPLACE(series.name, '%', '\\%'), '%')
       SQL
       next_set = new_deps.map(&:id) - result_set
       result_set += next_set
     end
-    ##Series.reload_by_dependency_depth Series.where id: result_set
+    Series.reload_by_dependency_depth Series.where id: result_set
   end
 
   def Series.reload_by_dependency_depth(series_list = Series.get_all_uhero)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1047,7 +1047,7 @@ class Series < ActiveRecord::Base
   def Series.reload_by_dependency_depth(series_list = Series.get_all_uhero)
     require 'redis'
     redis = Redis.new
-    puts 'Starting Reload by Dependency Depth'
+    logger.info { 'Starting Reload by Dependency Depth' }
     first_depth = series_list.order(:dependency_depth => :desc).first.dependency_depth
     series_size = series_list.count
     redis.pipelined do


### PR DESCRIPTION
This new method works by collecting the full tree of dependent series rooted at the starting series. It then passes that list of series to the existing `Series.reload_by_dependency_depth` to do the reload in the right order. Unlike the nightly load, here we might have multiple contiguous depth layers that are empty, but the aforementioned appears to be designed to handle this case. This code depends on the `dependency_depth` column in the Series table being set correctly. It does not run the algorithm that sets these values before doing its work, because that would add 30+ minutes to the process. The `assign_dependency_depth` function runs every day at 11am (currently) on the cron, and it's probably fair to guess that in almost all cases nothing relevant will have changed. In special cases where the user knows that the depths need to be updated, the aforementioned can be run by hand.

Testing that the tree-walking algo here works correctly is problematic, because this is pretty much the minimal algorithm to do that computation. I tested by picking a series, basically at random, and tracing through the db by hand to build the tree. Luckily(?) I picked a series that had a decent-size tree (66 nodes) and made one mistake, which was revealed by comparing my hand output to the output of the code, suggesting that the code is doing the right thing. Also tried the following, with `Series.reload_by_dependency_depth` call commented out, just to see if anything would break, but it didn't: ``Series.where(%q{name like 'V%'}).each {|s| s.reload_with_dependencies }``