### PR TITLE
Make reload_with_dependencies operate on a list (UA-939)

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1031,7 +1031,7 @@ class Series < ActiveRecord::Base
     unless series_id_list.class == Array
       raise 'Series.reload_with_dependencies needs an array of series ids'
     end
-    logger.info { "reload_with_dependencies: series #{id} (#{name}): start" }
+    logger.info { "reload_with_dependencies: start" }
     result_set = series_id_list
     next_set = series_id_list
     until next_set.empty?
@@ -1049,7 +1049,7 @@ class Series < ActiveRecord::Base
       next_set = new_deps.map(&:id) - result_set
       result_set += next_set
     end
-    logger.info { "reload_with_dependencies: series #{id} (#{name}): ship off to reload_by_dependency_depth" }
+    logger.info { "reload_with_dependencies: ship off to reload_by_dependency_depth" }
     Series.reload_by_dependency_depth Series.where id: result_set
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1023,14 +1023,17 @@ class Series < ActiveRecord::Base
     end
   end
 
-  def Series.reload_with_dependencies(id)
-    Series.find(id).reload_with_dependencies
+  def reload_with_dependencies
+    Series.reload_with_dependencies([self.id])
   end
 
-  def reload_with_dependencies
+  def Series.reload_with_dependencies(series_id_list)
+    unless series_id_list.class == Array
+      raise 'Series.reload_with_dependencies needs an array of series ids'
+    end
     logger.info { "reload_with_dependencies: series #{id} (#{name}): start" }
-    result_set = [self.id]
-    next_set = [self.id]
+    result_set = series_id_list
+    next_set = series_id_list
     until next_set.empty?
       logger.debug { "reload_with_dependencies: next_set is #{next_set}" }
       qmarks = next_set.count.times.map{ '?' }.join(',')
@@ -1038,7 +1041,7 @@ class Series < ActiveRecord::Base
       ##   https://apidock.com/rails/ActiveRecord/Querying/find_by_sql (check sample code - method signature shown is wrong!)
       ##   https://stackoverflow.com/questions/18934542/rails-find-by-sql-and-parameter-for-id/49765762#49765762
       new_deps = Series.find_by_sql [<<~SQL, next_set].flatten
-        select distinct series_id as id
+        select distinct data_sources.series_id as id
         from data_sources, series
         where series.id in (#{qmarks})
         and dependencies like CONCAT('% ', REPLACE(series.name, '%', '\\%'), '%')


### PR DESCRIPTION
Pretty straightforward to make this method take a list of ids, rather than be an instance method with a single series as receiver. Also included are changes to the `batch_id` so that it includes a substring of an MD5 hash to distinguish cases where running jobs in parallel, and the timestamp and list length turn out the same.

I have tested by running the job du jour (all series with a data source defined with `load_from_file`) on the stage server and, except for the fact that the very last 2 series loads (out of 1312) seem to be stuck, it's looking good.