### PR TITLE
Use client-specific Redis URLs (UA-942)

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1056,7 +1056,7 @@ class Series < ActiveRecord::Base
   def Series.reload_by_dependency_depth(series_list = Series.get_all_uhero)
     require 'redis'
     require 'digest/md5'
-    redis = Redis.new
+    redis = Redis.new url: (ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
     logger.info { 'Starting Reload by Dependency Depth' }
     datetime = Time.now.strftime('%Y%m%d%H%MUTC')
     hash = Digest::MD5.new << "#{datetime}#{series_list.count}#{rand 100000}"
@@ -1079,7 +1079,7 @@ class Series < ActiveRecord::Base
   def Series.check_for_stalled_reload(series_size = Series.get_all_uhero.count)
     require 'redis'
     require 'sidekiq/api'
-    redis = Redis.new
+    redis = Redis.new url: (ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
 
     sidekiq_stats = Sidekiq::Stats.new
     current_depth = redis.get("current_depth_#{series_size}").to_i

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1056,7 +1056,7 @@ class Series < ActiveRecord::Base
   def Series.reload_by_dependency_depth(series_list = Series.get_all_uhero)
     require 'redis'
     require 'digest/md5'
-    redis = Redis.new url: (ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
+    redis = Redis.new(url: ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
     logger.info { 'Starting Reload by Dependency Depth' }
     datetime = Time.now.strftime('%Y%m%d%H%MUTC')
     hash = Digest::MD5.new << "#{datetime}#{series_list.count}#{rand 100000}"
@@ -1079,7 +1079,7 @@ class Series < ActiveRecord::Base
   def Series.check_for_stalled_reload(series_size = Series.get_all_uhero.count)
     require 'redis'
     require 'sidekiq/api'
-    redis = Redis.new url: (ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
+    redis = Redis.new(url: ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
 
     sidekiq_stats = Sidekiq::Stats.new
     current_depth = redis.get("current_depth_#{series_size}").to_i

--- a/app/workers/series_worker.rb
+++ b/app/workers/series_worker.rb
@@ -25,7 +25,7 @@ class SeriesWorker
 
     begin
       success = false
-      redis = Redis.new
+      redis = Redis.new url: (ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
       redis.pipelined do
         redis.decr keys[:queue]
         redis.incr keys[:busy_workers]

--- a/app/workers/series_worker.rb
+++ b/app/workers/series_worker.rb
@@ -25,7 +25,7 @@ class SeriesWorker
 
     begin
       success = false
-      redis = Redis.new url: (ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
+      redis = Redis.new(url: ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
       redis.pipelined do
         redis.decr keys[:queue]
         redis.incr keys[:busy_workers]

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,12 @@
 Sidekiq.configure_server do |config|
+  config.redis = { url: ENV['REDIS_SIDEKIQ_URL'] || ENV['REDIS_URL'] }
+
   ## All Rails logging should go to the Sidekiq logger when code is running in Sidekiq
   # but this doesn't seem to be working as expected at present :(
   Rails.logger = Sidekiq::Logging.logger
-
-  config.redis = { url: ENV['REDIS_SIDEKIQ_URL'] }
 end
 
+# https://github.com/mperham/sidekiq/wiki/Using-Redis
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV['REDIS_SIDEKIQ_URL'] }
+  config.redis = { url: ENV['REDIS_SIDEKIQ_URL'] || ENV['REDIS_URL'] }
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,11 @@
 Sidekiq.configure_server do |config|
   ## All Rails logging should go to the Sidekiq logger when code is running in Sidekiq
+  # but this doesn't seem to be working as expected at present :(
   Rails.logger = Sidekiq::Logging.logger
 
+  config.redis = { url: ENV['REDIS_SIDEKIQ_URL'] }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV['REDIS_SIDEKIQ_URL'] }
 end


### PR DESCRIPTION
I have run a test with this code on stage and with the new infra setup: two Redis instances of the new version (4.0.9) - one for sidekiq and one for others (series worker and rest-api). Both Redises are being used appropriately. Run of mini-nightly on a subset of series completed without incident. Fwiw rest-api also working fine against the new Redis version.

I think we're in good shape to transition prod to two new Redises of new version, but we'll talk tomorrow :=)