### PR TITLE
Make UI showing series that have run/not run during the last nightly load (UA-944)

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -285,22 +285,14 @@ class SeriesController < ApplicationController
   end
 
   def stale
-    yester = Time.now.yesterday
-    horizon = Time.new(yester.year, yester.month, yester.day, 21, 0, 0)  ## 9pm the day before
-    stales = Series.get_all_uhero
-                   .joins(:data_sources)
-                   .where('reload_nightly = true AND last_run_in_seconds < ?', horizon.to_i)
-                   .order('series.name, data_sources.id')
-                   .pluck('series.id, series.name, data_sources.id')
-    @stale_series = {}
-    stales.each do |s_id, s_name, ds_id|
-      @stale_series[s_id] ||= { name: s_name, dsids: [] }
-      @stale_series[s_id][:dsids].push ds_id
-    end
-    @stale_series
+    @stale_series = Series.stale_since Time.now.days_ago(2)
   end
 
-  private
+  def nightly_missed
+    @stale_series = Series.stale_since Time.now.yesterday
+  end
+
+private
     def series_params
       params.require(:series).permit(
           :universe,

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -285,14 +285,36 @@ class SeriesController < ApplicationController
   end
 
   def stale
-    @stale_series = Series.stale_since Time.now.days_ago(2)
+    @stale_series = {}
+    stales = Series.stale_since Time.now.days_ago(2)
+    stales.each do |s_id, s_name, ds_id|
+      @stale_series[s_id] ||= { name: s_name, dsids: [] }
+      @stale_series[s_id][:dsids].push ds_id
+    end
+    @stale_series
   end
 
   def nightly_missed
-    @stale_series = Series.stale_since Time.now.yesterday
+    @missed_series = {}
+    missed = Series.stale_since Time.now.yesterday
+    missed.each do |s_id, s_name, ds_id|
+      @missed_series[s_id] ||= { name: s_name, dsids: [] }
+      @missed_series[s_id][:dsids].push ds_id
+    end
+    @missed_series
   end
 
-private
+  def nightly_loaded
+    @loaded_series = {}
+    loaded = Series.loaded_since Time.now.yesterday
+    loaded.each do |s_id, s_name, ds_id|
+      @loaded_series[s_id] ||= { name: s_name, dsids: [] }
+      @loaded_series[s_id][:dsids].push ds_id
+    end
+    @loaded_series
+  end
+
+  private
     def series_params
       params.require(:series).permit(
           :universe,

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -285,9 +285,11 @@ class SeriesController < ApplicationController
   end
 
   def stale
+    yester = Time.now.yesterday
+    horizon = Time.new(yester.year, yester.month, yester.day, 21, 0, 0)  ## 9pm the day before
     stales = Series.get_all_uhero
                    .joins(:data_sources)
-                   .where('reload_nightly = true AND last_run_in_seconds < ?', Time.now.days_ago(2).to_i)
+                   .where('reload_nightly = true AND last_run_in_seconds < ?', horizon.to_i)
                    .order('series.name, data_sources.id')
                    .pluck('series.id, series.name, data_sources.id')
     @stale_series = {}

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1115,6 +1115,20 @@ class Series < ActiveRecord::Base
     series.sort{|x,y| x.name <=> y.name }
   end
 
+  def Series.stale_since(past_day)
+    horizon = Time.new(past_day.year, past_day.month, past_day.day, 21, 0, 0)  ## 9pm, roughly when nightly load starts
+    stales = Series.get_all_uhero
+                 .joins(:data_sources)
+                 .where('reload_nightly = true AND last_run_in_seconds < ?', horizon.to_i)
+                 .order('series.name, data_sources.id')
+                 .pluck('series.id, series.name, data_sources.id')
+    series_hash = {}
+    stales.each do |s_id, s_name, ds_id|
+      series_hash[s_id] ||= { name: s_name, dsids: [] }
+      series_hash[s_id][:dsids].push ds_id
+    end
+    series_hash
+  end
 
 private
   def Series.display_options(options)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1056,11 +1056,12 @@ class Series < ActiveRecord::Base
   def Series.reload_by_dependency_depth(series_list = Series.get_all_uhero)
     require 'redis'
     require 'digest/md5'
-    redis = Redis.new(url: ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
-    logger.info { 'Starting Reload by Dependency Depth' }
     datetime = Time.now.strftime('%Y%m%d%H%MHST')
     hash = Digest::MD5.new << "#{datetime}#{series_list.count}#{rand 100000}"
     batch_id = "#{datetime}_#{series_list.count}_#{hash.to_s[-6..-1]}"
+    logger.info { "Starting Reload by Dependency Depth: batch_id #{batch_id}" }
+
+    redis = Redis.new(url: ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
     first_depth = series_list.order(:dependency_depth => :desc).first.dependency_depth
     redis.pipelined do
       redis.set("current_depth_#{batch_id}", first_depth)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1125,12 +1125,11 @@ class Series < ActiveRecord::Base
   end
 
   def Series.loaded_since(past_day)
-    horizon = Time.new(past_day.year, past_day.month, past_day.day, 21, 0, 0)  ## 9pm, roughly when nightly load starts
     Series.get_all_uhero
         .joins(:data_sources)
-        .where('reload_nightly = true AND last_run_in_seconds > ?', horizon.to_i)
+        .where(reload_nightly: true)
         .order('series.name, data_sources.id')
-        .pluck('series.id, series.name, data_sources.id')
+        .pluck('series.id, series.name, data_sources.id') - Series.stale_since(past_day)
   end
 
 private

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1127,7 +1127,7 @@ class Series < ActiveRecord::Base
   def Series.loaded_since(past_day)
     Series.get_all_uhero
         .joins(:data_sources)
-        .where(reload_nightly: true)
+        .where('reload_nightly = true')
         .order('series.name, data_sources.id')
         .pluck('series.id, series.name, data_sources.id') - Series.stale_since(past_day)
   end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1058,7 +1058,7 @@ class Series < ActiveRecord::Base
     require 'digest/md5'
     redis = Redis.new(url: ENV['REDIS_WORKER_URL'] || ENV['REDIS_URL'])
     logger.info { 'Starting Reload by Dependency Depth' }
-    datetime = Time.now.strftime('%Y%m%d%H%MUTC')
+    datetime = Time.now.strftime('%Y%m%d%H%MHST')
     hash = Digest::MD5.new << "#{datetime}#{series_list.count}#{rand 100000}"
     batch_id = "#{datetime}_#{series_list.count}_#{hash.to_s[-6..-1]}"
     first_depth = series_list.order(:dependency_depth => :desc).first.dependency_depth

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1117,17 +1117,20 @@ class Series < ActiveRecord::Base
 
   def Series.stale_since(past_day)
     horizon = Time.new(past_day.year, past_day.month, past_day.day, 21, 0, 0)  ## 9pm, roughly when nightly load starts
-    stales = Series.get_all_uhero
-                 .joins(:data_sources)
-                 .where('reload_nightly = true AND last_run_in_seconds < ?', horizon.to_i)
-                 .order('series.name, data_sources.id')
-                 .pluck('series.id, series.name, data_sources.id')
-    series_hash = {}
-    stales.each do |s_id, s_name, ds_id|
-      series_hash[s_id] ||= { name: s_name, dsids: [] }
-      series_hash[s_id][:dsids].push ds_id
-    end
-    series_hash
+    Series.get_all_uhero
+          .joins(:data_sources)
+          .where('reload_nightly = true AND last_run_in_seconds < ?', horizon.to_i)
+          .order('series.name, data_sources.id')
+          .pluck('series.id, series.name, data_sources.id')
+  end
+
+  def Series.loaded_since(past_day)
+    horizon = Time.new(past_day.year, past_day.month, past_day.day, 21, 0, 0)  ## 9pm, roughly when nightly load starts
+    Series.get_all_uhero
+        .joins(:data_sources)
+        .where('reload_nightly = true AND last_run_in_seconds > ?', horizon.to_i)
+        .order('series.name, data_sources.id')
+        .pluck('series.id, series.name, data_sources.id')
   end
 
 private

--- a/app/views/dashboards/investigate_visual.html.erb
+++ b/app/views/dashboards/investigate_visual.html.erb
@@ -327,8 +327,9 @@
 		<h2>New Data Points and Updated Series</h2>
 		<svg id="new_data_points"></svg>
     <div id="sidekiq_failures">
-      <br/><br/><br/><br/>
-      <%= link_to "Series that failed nightly loading: #{SidekiqFailure.count}", controller: :series, action: :sidekiq_failed %>
+      <br/><br/><br/>
+      <%= link_to 'Series that failed nightly loading', controller: :series, action: :nightly_missed %><br/>
+      <%= link_to 'Series that fully nightly loaded', controller: :series, action: :nightly_loaded %>
     </div>
 		</td>
 		<td>

--- a/app/views/series/nightly_loaded.html.erb
+++ b/app/views/series/nightly_loaded.html.erb
@@ -1,6 +1,7 @@
 <div id="summary_area">
 	<h2>Data Series loaded in the latest nightly</h2>
 	<h2>Total: <%= @loaded_series.count %></h2>
+  <%= link_to 'Series that failed nightly loading', controller: :series, action: :nightly_missed %>
 </div>
 <div id="details_mask"></div>
 <div id="details_area">

--- a/app/views/series/nightly_loaded.html.erb
+++ b/app/views/series/nightly_loaded.html.erb
@@ -1,0 +1,17 @@
+<div id="summary_area">
+	<h2>Data Series loaded in the latest nightly</h2>
+	<h2>Total: <%= @loaded_series.count %></h2>
+</div>
+<div id="details_mask"></div>
+<div id="details_area">
+		<ul>
+		<% @loaded_series.each do |id, hash| %>
+       <li><%= link_to hash[:name], { action: :show, id: id } %>
+         (<% hash[:dsids].each do |dsid| %>
+             <%= link_to dsid, { controller: :data_sources, action: :edit, id: dsid } %>
+          <% end %>)</li>
+    <% end %>
+		</ul>
+</div>
+
+<p>

--- a/app/views/series/nightly_missed.html.erb
+++ b/app/views/series/nightly_missed.html.erb
@@ -1,6 +1,7 @@
 <div id="summary_area">
 	<h2>Data Series missed in the latest nightly</h2>
 	<h2>Total: <%= @missed_series.count %></h2>
+  <%= link_to 'Series that fully nightly loaded', controller: :series, action: :nightly_loaded %>
 </div>
 <div id="details_mask"></div>
 <div id="details_area">

--- a/app/views/series/nightly_missed.html.erb
+++ b/app/views/series/nightly_missed.html.erb
@@ -1,0 +1,17 @@
+<div id="summary_area">
+	<h2>Data Series missed in the latest nightly</h2>
+	<h2>Total: <%= @missed_series.count %></h2>
+</div>
+<div id="details_mask"></div>
+<div id="details_area">
+		<ul>
+		<% @missed_series.each do |id, hash| %>
+       <li><%= link_to hash[:name], { action: :show, id: id } %>
+         (<% hash[:dsids].each do |dsid| %>
+             <%= link_to dsid, { controller: :data_sources, action: :edit, id: dsid } %>
+          <% end %>)</li>
+    <% end %>
+		</ul>
+</div>
+
+<p>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,10 @@
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV['REDIS_SIDEKIQ_URL'] || ENV['REDIS_URL'] }
 
-  ## All Rails logging should go to the Sidekiq logger when code is running in Sidekiq
-  # but this doesn't seem to be working as expected at present :(
+  ## All Rails logging should go to the Sidekiq logger when code is running in Sidekiq.
+  ## But it turns out this only works when logger is invoked as Rails.logger, but cases
+  ## where it is invoked only as logger, output goes to <environment>.log file. Will
+  ## solve the problem later.
   Rails.logger = Sidekiq::Logging.logger
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,8 @@ UheroDb::Application.routes.draw do
   get 'series/quarantine', to: 'series#quarantine'
   get 'series/old_bea_download', to: 'series#old_bea_download'
   get 'series/sidekiq_failed', to: 'series#sidekiq_failed'
+  get 'series/nightly_missed', to: 'series#nightly_missed'
+  get 'series/nightly_loaded', to: 'series#nightly_loaded'
 
   resources :series
 

--- a/lib/tasks/source_map.rake
+++ b/lib/tasks/source_map.rake
@@ -85,6 +85,7 @@ end
 task :reload_hiwi_series_only => :environment do
   t = Time.now
   #could also hard code this...
+  logger.info { 'Starting task reload_hiwi_series_only' }
   hiwi_series = Series.get_all_series_by_eval('hiwi.org')
   Series.reload_by_dependency_depth hiwi_series
   CSV.open('public/rake_time.csv', 'a') {|csv| csv << ['hiwi series dependency check and load', '%.2f' % (Time.now - t) , t.to_s, Time.now.to_s] }
@@ -93,6 +94,7 @@ end
 task :reload_bls_series_only => :environment do
   t = Time.now
   #could also hard code this...
+  logger.info { 'Starting task reload_bls_series_only' }
   bls_series = Series.get_all_series_by_eval('load_from_bls')
   Series.reload_by_dependency_depth bls_series
   CSV.open('public/rake_time.csv', 'a') {|csv| csv << ['bls series dependency check and load', '%.2f' % (Time.now - t) , t.to_s, Time.now.to_s] }
@@ -101,6 +103,7 @@ end
 task :reload_bea_series_only => :environment do
   t = Time.now
   #could also hard code this...
+  logger.info { 'Starting task reload_bea_series_only' }
   bea_series = Series.get_all_series_by_eval(%w{load_from_bea bea.gov})
   Series.reload_by_dependency_depth bea_series
   CSV.open('public/rake_time.csv', 'a') {|csv| csv << ['bea series dependency check and load', '%.2f' % (Time.now - t) , t.to_s, Time.now.to_s] }


### PR DESCRIPTION
I refreshed vagrant db with current prod before testing, but still it showed no series as having fully loaded last night. Not sure why, because presumably it should have shown some.... but if you push the horizon back > one day, seems to function as expected -- doesn't look like the logic is flawed, so I'd like to go ahead and release it and see what it reports tomorrow.

There are a few other minor things mixed in here.