### PR TITLE
Categories list data_list links should go to edit, not show (UA-960)

### DIFF
--- a/app/controllers/data_lists_controller.rb
+++ b/app/controllers/data_lists_controller.rb
@@ -159,14 +159,10 @@ class DataListsController < ApplicationController
 
     respond_to do |format|
       if @data_list.save
-        format.html {
-          if category
-            category.update_attributes(data_list_id: @data_list.id)
-            redirect_to edit_category_path(category)
-          else
-            redirect_to(@data_list, notice: 'Data list was successfully created.')
-          end
-        }
+        if category
+          category.update_attributes(data_list_id: @data_list.id)
+        end
+        format.html { redirect_to edit_data_list_path(@data_list) }
         format.xml  { render :xml => @data_list, :status => :created, :location => @data_list }
       else
         format.html { render :action => 'new' }

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -36,9 +36,9 @@ private
     icon_type = leaf.is_childless? ? 'fa-square' : 'fa-plus-square'
     data_list_section =
         case
-          when leaf.data_list then link_to(leaf.data_list.name, "data_lists/super_table/#{leaf.data_list_id}")
+          when leaf.data_list then link_to(leaf.data_list.name, {controller: :data_lists, action: :edit, id: leaf.data_list})
           when leaf.header then 'Header'
-          else 'No Data List'
+          else link_to('No Data List', {controller: :data_lists, action: :new, category_id: leaf})
         end
     name_part = '<span class="%s"><i class="fa %s" aria-hidden="true"></i> %s</span> (%s)' % [span_class, icon_type, leaf.name, data_list_section]
     unless leaf.default_geo_id.blank? && leaf.default_freq.blank?

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -29,7 +29,7 @@ class Category < ActiveRecord::Base
     max_sib = children.maximum(:list_order)
     defaults = {
         universe: universe,
-        name: 'XXX New child XXX',
+        name: 'NEW UNNAMED CATEGORY',
         masked: masked || hidden,
         list_order: max_sib.nil? ? 0 : max_sib + 1
     }

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -29,7 +29,7 @@ class Category < ActiveRecord::Base
     max_sib = children.maximum(:list_order)
     defaults = {
         universe: universe,
-        name: 'NEW UNNAMED CATEGORY',
+        name: '*** NEW UNNAMED CATEGORY ***',
         masked: masked || hidden,
         list_order: max_sib.nil? ? 0 : max_sib + 1
     }

--- a/app/views/data_lists/_form.html.erb
+++ b/app/views/data_lists/_form.html.erb
@@ -60,10 +60,7 @@
             <div class="field">
               <%= f2.label :measurements %><br>
               <%= f2.collection_select :measurement_ids, Measurement.where(universe: 'UHERO').all.order(:prefix, :data_portal_name), :id, :prefix_and_name, {:include_blank => false, selected: nil} %>
-            </div>
-            <div class="actions">
-              <%= f2.submit 'Add Measurement' %>
-            </div>
+            </div><span class="actions"><%= f2.submit 'Add Measurement' %></span>
         <% end %>
         <br />
   <% end %>

--- a/app/views/data_lists/_form.html.erb
+++ b/app/views/data_lists/_form.html.erb
@@ -60,7 +60,10 @@
             <div class="field">
               <%= f2.label :measurements %><br>
               <%= f2.collection_select :measurement_ids, Measurement.where(universe: 'UHERO').all.order(:prefix, :data_portal_name), :id, :prefix_and_name, {:include_blank => false, selected: nil} %>
-            </div><span class="actions"><%= f2.submit 'Add Measurement' %></span>
+            </div>
+            <div class="actions">
+              <%= f2.submit 'Add Measurement' %>
+            </div>
         <% end %>
         <br />
   <% end %>


### PR DESCRIPTION
Existing data list links changed accordingly. Also changed the `No Data List` label to a link to the `:new` action. Finally, realized that from a UX standpoint, to have new DL creation be followed by anything other than editing the new DL was likely to be a waste of time.