### PR TITLE
Keep Categories tree-list open (UA-961)

### DIFF
--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -3,25 +3,23 @@ function replayCategoryOpenTree() {
     console.log("!!!!!!!!!!!!!!!!!!!! THe nodeslist is "+nodesText);
     if (nodesText == undefined) return;
     var openNodeIds = Object.keys(JSON.parse(nodesText));
-    console.log("@@@@@@@@@@@@@@ The nodes array is "+openNodeIds.toString());
     for (var i = 0; i < openNodeIds.length; i++) {
         console.log("^^^^^^^^^^^^^^^^^^ doing object "+openNodeIds[i]);
-        var o = document.getElementById(openNodeIds[i]);
-        doowop(o);
+        categoryToggleUI(document.getElementById(openNodeIds[i]));
     }
 }
 
-function doowop(the) {
-    console.log("^^^^^^^^^^^^^^^^^^ object is "+the.toString());
-    var ul = $(the).parent().children('ul');
+function categoryToggleUI(node) {
+//    console.log("^^^^^^^^^^^^^^^^^^ object is "+the.toString());
+    var ul = $(node).parent().children('ul');
     ul.toggle();
-    var text = $(the).html();
+    var text = $(node).html();
     if (ul.is(':hidden')) {
-        $(the).html(text.replace('-minus-', '-plus-'));
+        $(node).html(text.replace('-minus-', '-plus-'));
         return true
     }
     else {
-        $(the).html(text.replace('-plus-', '-minus-'));
+        $(node).html(text.replace('-plus-', '-minus-'));
         return false
     }
 }
@@ -29,12 +27,13 @@ function doowop(the) {
 $(function() {
     $('.category_non_leaf').click(function() {
         var nodesText = sessionStorage.getItem('udamanCatTreeOpenNodes');
+        console.log("////////////////// Found stored opennodes |"+nodesText+"|");
         var openNodes = (nodesText == null) ? {} : JSON.parse(nodesText);
 //        var ul = $(this).parent().children('ul');
 //        ul.toggle();
 //        var text = $(this).html();
 //        if (ul.is(':hidden')) {
-        if (doowop($(this))) {
+        if (categoryToggleUI($(this))) {
 //            $(this).html(text.replace('-minus-', '-plus-'));
             console.log("<<<<<<<<<<<< deleting from nodeslist: "+$(this).attr('id'));
             delete openNodes[$(this).attr('id')];

--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -1,16 +1,13 @@
 function replayCategoryOpenTree() {
     var nodesText = sessionStorage.getItem('udamanCatTreeOpenNodes');
-    console.log("!!!!!!!!!!!!!!!!!!!! THe nodeslist is "+nodesText);
     if (nodesText == undefined) return;
     var openNodeIds = Object.keys(JSON.parse(nodesText));
     for (var i = 0; i < openNodeIds.length; i++) {
-        console.log("^^^^^^^^^^^^^^^^^^ doing object "+openNodeIds[i]);
         categoryToggleUI(document.getElementById(openNodeIds[i]));
     }
 }
 
 function categoryToggleUI(node) {
-//    console.log("^^^^^^^^^^^^^^^^^^ object is "+the.toString());
     var ul = $(node).parent().children('ul');
     ul.toggle();
     var text = $(node).html();
@@ -27,21 +24,13 @@ function categoryToggleUI(node) {
 $(function() {
     $('.category_non_leaf').click(function() {
         var nodesText = sessionStorage.getItem('udamanCatTreeOpenNodes');
-        console.log("////////////////// Found stored opennodes |"+nodesText+"|");
         var openNodes = (nodesText == null) ? {} : JSON.parse(nodesText);
-//        var ul = $(this).parent().children('ul');
-//        ul.toggle();
-//        var text = $(this).html();
-//        if (ul.is(':hidden')) {
+        var thisId = $(this).attr('id');
         if (categoryToggleUI($(this))) {
-//            $(this).html(text.replace('-minus-', '-plus-'));
-            console.log("<<<<<<<<<<<< deleting from nodeslist: "+$(this).attr('id'));
-            delete openNodes[$(this).attr('id')];
+            delete openNodes[thisId];
         }
         else {
-//            $(this).html(text.replace('-plus-', '-minus-'));
-            console.log(">>>>>>>>>>> adding to nodeslist: "+$(this).attr('id'));
-            openNodes[$(this).attr('id')] = 1;
+            openNodes[thisId] = 1;
         }
         sessionStorage.setItem('udamanCatTreeOpenNodes', JSON.stringify(openNodes))
     });

--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -1,14 +1,19 @@
 $(function() {
     $('.category_non_leaf').click(function() {
+        var nodesText = sessionStorage.getItem('categoryTreeOpenNodes');
+        var openNodes = (nodesText == null) ? {} : JSON.parse(nodesText);
         var ul = $(this).parent().children('ul');
         ul.toggle();
         var text = $(this).html();
         if (ul.is(':hidden')) {
             $(this).html(text.replace('-minus-', '-plus-'));
+            delete openNodes[$(this).id];
         }
         else {
             $(this).html(text.replace('-plus-', '-minus-'));
+            openNodes[$(this).id] = 1;
         }
+        sessionStorage.setItem('categoryTreeOpenNodes', JSON.stringify(openNodes))
     });
     $('#toggle_all').click(function () {
         var text = $(this).html();

--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -7,21 +7,21 @@ function replayCategoryOpenTree() {
     for (var i = 0; i < openNodeIds.length; i++) {
         console.log("^^^^^^^^^^^^^^^^^^ doing object "+openNodeIds[i]);
         var o = document.getElementById(openNodeIds[i]);
-        console.log("^^^^^^^^^^^^^^^^^^ object is "+o.toString());
         doowop(o);
     }
 }
 
 function doowop(the) {
-    var ul = the.parent().children('ul');
+    console.log("^^^^^^^^^^^^^^^^^^ object is "+the.toString());
+    var ul = $(the).parent().children('ul');
     ul.toggle();
-    var text = the.html();
+    var text = $(the).html();
     if (ul.is(':hidden')) {
-        the.html(text.replace('-minus-', '-plus-'));
+        $(the).html(text.replace('-minus-', '-plus-'));
         return true
     }
     else {
-        the.html(text.replace('-plus-', '-minus-'));
+        $(the).html(text.replace('-plus-', '-minus-'));
         return false
     }
 }

--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -1,20 +1,52 @@
+function replayCategoryOpenTree() {
+    var nodesText = sessionStorage.getItem('udamanCatTreeOpenNodes');
+    console.log("!!!!!!!!!!!!!!!!!!!! THe nodeslist is "+nodesText);
+    if (nodesText == undefined) return;
+    var openNodeIds = Object.keys(JSON.parse(nodesText));
+    console.log("@@@@@@@@@@@@@@ The nodes array is "+openNodeIds.toString());
+    for (var i = 0; i < openNodeIds.length; i++) {
+        console.log("^^^^^^^^^^^^^^^^^^ doing object "+openNodeIds[i]);
+        var o = document.getElementById(openNodeIds[i]);
+        console.log("^^^^^^^^^^^^^^^^^^ object is "+o.toString());
+        doowop(o);
+    }
+}
+
+function doowop(the) {
+    var ul = the.parent().children('ul');
+    ul.toggle();
+    var text = the.html();
+    if (ul.is(':hidden')) {
+        the.html(text.replace('-minus-', '-plus-'));
+        return true
+    }
+    else {
+        the.html(text.replace('-plus-', '-minus-'));
+        return false
+    }
+}
+
 $(function() {
     $('.category_non_leaf').click(function() {
-        var nodesText = sessionStorage.getItem('categoryTreeOpenNodes');
+        var nodesText = sessionStorage.getItem('udamanCatTreeOpenNodes');
         var openNodes = (nodesText == null) ? {} : JSON.parse(nodesText);
-        var ul = $(this).parent().children('ul');
-        ul.toggle();
-        var text = $(this).html();
-        if (ul.is(':hidden')) {
-            $(this).html(text.replace('-minus-', '-plus-'));
-            delete openNodes[$(this).id];
+//        var ul = $(this).parent().children('ul');
+//        ul.toggle();
+//        var text = $(this).html();
+//        if (ul.is(':hidden')) {
+        if (doowop($(this))) {
+//            $(this).html(text.replace('-minus-', '-plus-'));
+            console.log("<<<<<<<<<<<< deleting from nodeslist: "+$(this).attr('id'));
+            delete openNodes[$(this).attr('id')];
         }
         else {
-            $(this).html(text.replace('-plus-', '-minus-'));
-            openNodes[$(this).id] = 1;
+//            $(this).html(text.replace('-plus-', '-minus-'));
+            console.log(">>>>>>>>>>> adding to nodeslist: "+$(this).attr('id'));
+            openNodes[$(this).attr('id')] = 1;
         }
-        sessionStorage.setItem('categoryTreeOpenNodes', JSON.stringify(openNodes))
+        sessionStorage.setItem('udamanCatTreeOpenNodes', JSON.stringify(openNodes))
     });
+
     $('#toggle_all').click(function () {
         var text = $(this).html();
         if (text == 'Expand all') {

--- a/app/assets/javascripts/measurements.js
+++ b/app/assets/javascripts/measurements.js
@@ -5,15 +5,16 @@
 function toggleAllFields() {
     var me = document.getElementById('all_fields_check');
     var elements = document.querySelectorAll('[id^=field_boxes_]');
-    if (me.innerHTML == 'Select all fields') {
-        for (i=0; i < elements.length; i++) {
+    var i;
+    if (me.innerHTML === 'Select all fields') {
+        for (i = 0; i < elements.length; i++) {
             // True for all except disabled boxes
             elements[i].checked = !elements[i].disabled;
         }
         me.innerHTML = 'Unselect all fields';
     }
     else {
-        for (i=0; i < elements.length; i++) {
+        for (i = 0; i < elements.length; i++) {
             elements[i].checked = false;
         }
         me.innerHTML = 'Select all fields';
@@ -23,14 +24,15 @@ function toggleAllFields() {
 function toggleAllSeries() {
     var me = document.getElementById('all_series_check');
     var elements = document.querySelectorAll('[id^=series_boxes_]');
-    if (me.innerHTML == 'Select all series') {
-        for (i=0; i < elements.length; i++) {
+    var i;
+    if (me.innerHTML === 'Select all series') {
+        for (i = 0; i < elements.length; i++) {
             elements[i].checked = true;
         }
         me.innerHTML = 'Unselect all series';
     }
     else {
-        for (i=0; i < elements.length; i++) {
+        for (i = 0; i < elements.length; i++) {
             elements[i].checked = false;
         }
         me.innerHTML = 'Select all series';

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -79,6 +79,7 @@ private
 
   def new_span_id(node)
     require 'digest/md5'
+    return if node.is_childless?
     seed_string = node.ancestors.map{|a| a.name }.concat([node.name]).to_s
     hash = Digest::MD5.new << seed_string
     'cat_' + hash.to_s[0..9]

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,5 +1,4 @@
 module CategoriesHelper
-  require 'digest/md5'
 
   def show_table(root, first, last)
     list_item = show_list_item(root, first, last)
@@ -42,9 +41,8 @@ private
           when leaf.header then 'Header'
           else link_to('No Data List', {controller: :data_lists, action: :new, category_id: leaf})
         end
-    id_hash = leaf.is_childless? ? nil : Digest::MD5.new << leaf.ancestors.map{|a| a.name }.concat([leaf.name]).to_s
     name_part = '<span class="%s" id="%s"><i class="fa %s" aria-hidden="true"></i> %s</span> (%s)' %
-        [span_class, id_hash, icon_type, leaf.name, data_list_section]
+        [span_class, new_span_id(leaf), icon_type, leaf.name, data_list_section]
     unless leaf.default_geo_id.blank? && leaf.default_freq.blank?
       name_part += ' [%s.%s]' % [leaf.default_geo_handle, leaf.default_freq]
     end
@@ -79,4 +77,10 @@ private
       link_to('Down', "/categories/down/#{leaf.id}")
   end
 
+  def new_span_id(node)
+    require 'digest/md5'
+    seed_string = node.ancestors.map{|a| a.name }.concat([node.name]).to_s
+    hash = Digest::MD5.new << seed_string
+    'cat_' + hash.to_s[0..9]
+  end
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,4 +1,6 @@
 module CategoriesHelper
+  require 'digest/md5'
+
   def show_table(root, first, last)
     list_item = show_list_item(root, first, last)
     return "<li>#{list_item}</li>\n" if root.is_childless?
@@ -40,7 +42,9 @@ private
           when leaf.header then 'Header'
           else link_to('No Data List', {controller: :data_lists, action: :new, category_id: leaf})
         end
-    name_part = '<span class="%s"><i class="fa %s" aria-hidden="true"></i> %s</span> (%s)' % [span_class, icon_type, leaf.name, data_list_section]
+    id_hash = leaf.is_childless? ? nil : Digest::MD5.new << leaf.ancestors.map{|a| a.name }.concat([leaf.name]).to_s
+    name_part = '<span class="%s" id="%s"><i class="fa %s" aria-hidden="true"></i> %s</span> (%s)' %
+        [span_class, id_hash, icon_type, leaf.name, data_list_section]
     unless leaf.default_geo_id.blank? && leaf.default_freq.blank?
       name_part += ' [%s.%s]' % [leaf.default_geo_handle, leaf.default_freq]
     end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -10,3 +10,6 @@ Categories can be <span class="hidden_category">hidden</span>, or <span class="m
       <%= show_table(@category_roots[i], i == 0, i + 1 == @category_roots.length).html_safe %>
   <% end %>
 </ul>
+<script language="JavaScript">
+  replayCategoryOpenTree();
+</script>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Listing Categories</h1>
+<h1>Categories</h1>
 Categories can be <span class="hidden_category">hidden</span>, or <span class="masked_category">masked</span> by a hidden ancestor.
 <p>
 <span id="toggle_all" style="cursor:pointer;cursor:hand;">Expand all</span>


### PR DESCRIPTION
Categories index (tree list) page remembers which nodes are open, across any other activity, within the same browser tab. Close the tab, and it forgets. Uses browser's built-in `sessionStorage` API to keep the info.

Note: changes to `measurements.js` file are just stylistic improvements, unrelated to PR functionality.