### PR TITLE
Remove dependent resources when a resource is removed from udaman (UA-885)

### DIFF
--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -15,7 +15,7 @@ class DataSourcesController < ApplicationController
   end
   
   def delete
-    if @data_source.delete
+    if @data_source.destroy
       create_action @data_source, 'DELETE'
     end
     redirect_to controller: :series, action: :show, id: @data_source.series_id

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -55,14 +55,13 @@ class SeriesController < ApplicationController
     prefix = params.has_key?(:prefix) ? params[:prefix] : nil
     all = params.has_key?(:all) ? true : false
 
-    series =
+    @all_series =
       case
         when prefix then    Series.get_all_uhero.where('name LIKE ?', "#{prefix}%").order(:name)
         when frequency then Series.get_all_uhero.where('frequency LIKE ?', frequency).order(:name)
         when all then       Series.get_all_uhero.order(:name)
         else []
       end
-    @all_series = series.empty? ? [] : series.paginate(page: params[:page], per_page: 100)
   end
 
   def show

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -3,7 +3,7 @@ class DataSource < ActiveRecord::Base
   serialize :dependencies, Array
   
   belongs_to :series
-  has_many :data_points
+  has_many :data_points, dependent: :delete_all
   has_many :data_source_downloads, dependent: :delete_all
   has_many :data_source_actions
   has_many :downloads, -> {distinct}, through: :data_source_downloads

--- a/app/models/data_source_action.rb
+++ b/app/models/data_source_action.rb
@@ -1,5 +1,5 @@
 class DataSourceAction < ActiveRecord::Base
   belongs_to :series
-  belongs_to :users
+  belongs_to :user
   belongs_to :data_source
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,5 +1,5 @@
 class Export < ActiveRecord::Base
-  has_many :export_series
+  has_many :export_series, dependent: :delete_all
   has_many :series, -> {distinct}, through: :export_series
   accepts_nested_attributes_for :series
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -21,7 +21,7 @@ class Series < ActiveRecord::Base
   
   has_many :data_points, dependent: :delete_all
   has_many :data_sources, dependent: :destroy
-  has_many :data_source_actions, -> { order 'created_at DESC' }
+  has_many :data_source_actions, -> { order 'created_at DESC' }, dependent: :delete_all
   has_many :sidekiq_failures  ## really only has one, but stupid Rails error prevented relation from working with has_one :(
 
   has_and_belongs_to_many :data_lists

--- a/app/views/exports/_form.html.erb
+++ b/app/views/exports/_form.html.erb
@@ -25,7 +25,7 @@
           <tbody>
           <% @export.export_series.to_a.sort_by{|s| s.list_order}.map{|s| s.series}.each do |series| %>
               <tr>
-                <td><%= series.name %></td>
+                <td><%= link_to series.name, series %></td>
                 <td><%= link_to 'Up', {controller: :exports, action: :move_series_up, id: @export, series_id: series.id}, remote: true, data: {up: true} %></td>
                 <td><%= link_to 'Down', {controller: :exports, action: :move_series_down, id: @export, series_id: series.id}, remote: true, data: {down: true} %></td>
                 <td><%= link_to 'Remove', {controller: :exports, action: :remove_series, id: @export, series_id: series.id}, remote: true, data: {remove: true} %></td>

--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -21,7 +21,7 @@
         <td><%= link_to 'CSV', action: 'show', id: export, format: 'csv' %></td>
         <td><%= link_to 'Table', action: 'show_table', id: export %></td>
         <td><%= link_to 'Edit', edit_export_path(export) %></td>
-        <td><%= link_to 'Destroy', export, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Destroy', export, method: :delete, data: { confirm: "Destroy export #{export.name}\nAre you sure??" } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -31,8 +31,6 @@
 		<%= render :partial => 'calculate_form' %>
 
 <% unless @all_series.empty? %>
-  <%= will_paginate @all_series %>
-
   <table class="list_table">
     <thead>
     <tr>
@@ -62,7 +60,6 @@
     <% end %>
     </tbody>
   </table>
-  <%= will_paginate @all_series %>
   <p>
 <% end %>
 </div>


### PR DESCRIPTION
Add Activerecord relation specs that were missing to several models.

Also and separately, remove the pagination from series alpha-listing screens and other very minor UI.