### PR TITLE
Bugfix: limit the length of strings going into last_error, also BEA API errors

### DIFF
--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -180,7 +180,7 @@ class DataSource < ActiveRecord::Base
         self.update(:last_run => t,
                     :last_run_at => t,
                     :runtime => nil,
-                    :last_error => e.message,
+                    :last_error => e.message[0..254],
                     :last_error_at => t)
         Rails.logger.error { "Reload data source #{id} for series #{self.series.name} [#{description}]: Error: #{e.message}" }
         return false

--- a/app/workers/xls_csv_worker.rb
+++ b/app/workers/xls_csv_worker.rb
@@ -45,7 +45,7 @@ class XlsCsvWorker
     rescue => error
       logger.error error.message
       logger.error error.backtrace
-      dbu.update(last_error: error.message, last_error_at: Time.now)
+      dbu.update(last_error: error.message[0..254], last_error_at: Time.now)
       dbu.set_status(which, :fail)
     end
   end

--- a/lib/data_html_parser.rb
+++ b/lib/data_html_parser.rb
@@ -51,13 +51,13 @@ class DataHtmlParser
     Rails.logger.debug { "Getting URL from BEA API: #{@url}" }
     @doc = self.download
     response = JSON.parse self.content
-    raise 'BEA API: major unknown failure' unless response['BEAAPI']
-    err = response['BEAAPI']['Error']
+    beaapi = response['BEAAPI'] || raise('BEA API: major unknown failure')
+    raise 'BEA API: no results included' unless beaapi['Results'] || beaapi['Error']
+    err = beaapi['Error'] || beaapi['Results'] && beaapi['Results']['Error']
     if err
-      raise 'BEA API: Error: %s%s (code=%s)' % [err['APIErrorDescription'], err['AdditionalDetail'], err['APIErrorCode']]
+      raise 'BEA API Error: %s%s (code=%s)' % [err['APIErrorDescription'], err['AdditionalDetail'], err['APIErrorCode']]
     end
-    raise 'BEA API: no results included' unless response['BEAAPI']['Results']
-    results_data = response['BEAAPI']['Results']['Data']
+    results_data = beaapi['Results']['Data']
     raise 'BEA API: results, but no data' unless results_data
 
     new_data = {}


### PR DESCRIPTION
Also, fix up the way errors in the BEA API are handled.