### PR TITLE
VSO series missing January data point but loading following ones (UA-1083)

### DIFF
--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -21,6 +21,10 @@ class DataSourcesController < ApplicationController
     redirect_to controller: :series, action: :show, id: @data_source.series_id
   end
 
+  def reset
+    @data_source.reset
+  end
+
   def toggle_reload_nightly
     @data_source.toggle_reload_nightly
     redirect_to controller: :series, action: :show, id: @data_source.series_id

--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -43,10 +43,8 @@ class DataSourcesController < ApplicationController
   end
 
   def update
-    @data_source.update_attributes(:priority => params[:data_source][:priority].to_i)
-    if @data_source.update_attributes(:eval => params[:data_source][:eval])
+    if @data_source.update_attributes(eval: data_source_params[:eval], priority: data_source_params[:priority])
       create_action @data_source, 'UPDATE'
-      @data_source.reload_source
       redirect_to :controller => 'series', :action => 'show', :id => @data_source.series_id, :notice => 'datasource processed successfully'
     else
       redirect_to :controller => 'series', :action => 'show', :id => @data_source.series_id, :notice => 'datasource had a problem'
@@ -54,10 +52,9 @@ class DataSourcesController < ApplicationController
   end
 
   def inline_update
-    if @data_source.update_attributes(:eval => params[:data_source][:eval])
+    if @data_source.update_attributes(eval: data_source_params[:eval])
       create_action @data_source, 'UPDATE'
       begin
-        @data_source.reload_source
         render partial: 'inline_edit', locals: {:ds => @data_source, :notice => "OK, (#{@data_source.series.aremos_diff})"}
       rescue
         render partial: 'inline_edit', locals: {:ds => @data_source, :notice => 'BROKE ON LOAD'}

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -217,7 +217,15 @@ class DataSource < ActiveRecord::Base
     def clear_and_reload_source
       reload_source(true)
     end
-    
+
+    def reset
+      self.data_source_downloads.each do |dsd|
+        dsd.update_attributes(
+            last_file_vers_used: DateTime.parse('1970-01-01'), ## the column default value
+            last_eval_options_used: nil)
+      end
+    end
+
     # DataSource.where("eval LIKE '%bls_histextend_date_format_correct.xls%'").each {|ds| ds.mark_as_pseudo_history}
     
     def mark_as_pseudo_history

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -26,7 +26,8 @@
 							:id => ds.id },
 							data: { :confirm => "Are you sure you want to delete data source #{ds.id}?" }
 					%><br/><%=
-							link_to "edit", { 	
+              link_to "reset", { controller: :data_sources,action: :reset, id: ds.id }
+							link_to "edit", {
 								:controller=> "data_sources", 
 								:action => 'edit', 
 								:id => ds.id}

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -26,11 +26,9 @@
 							:id => ds.id },
 							data: { :confirm => "Are you sure you want to delete data source #{ds.id}?" }
 					%><br/><%=
-              link_to "reset", { controller: :data_sources,action: :reset, id: ds.id }
-							link_to "edit", {
-								:controller=> "data_sources", 
-								:action => 'edit', 
-								:id => ds.id}
+              link_to 'reset', { controller: :data_sources, action: :reset, id: ds.id }
+          %>&nbsp;|&nbsp;<%=
+              link_to 'edit', { controller: :data_sources, action: :edit, id: ds.id }
 					%>
         <span style="color:gray">(<%= "#{ds.runtime.round(2)}s" unless ds.runtime.nil? %>)</span><br/>
         <%= link_to nightly_actuator(ds.reload_nightly), {controller: :data_sources, action: :toggle_reload_nightly, id: ds.id} %>

--- a/lib/series_data_adjustment.rb
+++ b/lib/series_data_adjustment.rb
@@ -102,12 +102,12 @@ module SeriesDataAdjustment
   end
 
   def shift_by_months(num_months)
-    new_transformation("Shifted Series #{self.name} by #{num_months} months ",
+    new_transformation("Shifted Series #{self.name} by #{num_months} months",
              self.data.map {|date,val| [date + num_months.months, val] }.to_h)
   end
 
   def shift_by_years(num_years)
-    new_transformation("Shifted Series #{self.name} by #{num_years} months ",
+    new_transformation("Shifted Series #{self.name} by #{num_years} months",
              self.data.map {|date,val| [date + num_years.years, val] }.to_h)
   end
 

--- a/lib/series_data_adjustment.rb
+++ b/lib/series_data_adjustment.rb
@@ -100,7 +100,17 @@ module SeriesDataAdjustment
     return {} if month_num > 12 or month_num < 1
     data.reject {|date_string, _| date_string.month != month_num}
   end
-  
+
+  def shift_by_months(num_months)
+    new_transformation("Shifted Series #{self.name} by #{num_months} months ",
+             self.data.map {|date,val| [date + num_months.months, val] }.to_h)
+  end
+
+  def shift_by_years(num_years)
+    new_transformation("Shifted Series #{self.name} by #{num_years} months ",
+                       self.data.map {|date,val| [date + num_years.years, val] }.to_h)
+  end
+
   def shift_forward_months(num_months)
     new_series_data = Hash[data.map {|date, val| [date + num_months.months, val]}]
     new_transformation("Shifted Series #{name} forward by #{num_months} months ", new_series_data)

--- a/lib/series_data_adjustment.rb
+++ b/lib/series_data_adjustment.rb
@@ -108,7 +108,7 @@ module SeriesDataAdjustment
 
   def shift_by_years(num_years)
     new_transformation("Shifted Series #{self.name} by #{num_years} months ",
-                       self.data.map {|date,val| [date + num_years.years, val] }.to_h)
+             self.data.map {|date,val| [date + num_years.years, val] }.to_h)
   end
 
   def shift_forward_months(num_months)


### PR DESCRIPTION
Adding `reset` function to the data sources UI to clear out the state info that is stored in `data_source_downloads` that allows data points updates to be skipped, but sometimes we don't want them to be skipped. Also got rid of automatic `reload_source` call on data source eval or priority update.

Couple methods defs got included in here that are not really related, but they should cause no trouble.