### PR TITLE
Cannot look up resources by unique name after universe split (UA-1176)

### DIFF
--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -119,8 +119,8 @@ class MeasurementsController < ApplicationController
       return
     end
     new_vals_hash = fields_to_update.map{|f| [translate(f), @measurement.read_attribute(f)] }.to_h
-    series.keys.each {|s| Series.find_by(name: s).update_attributes new_vals_hash }
-    redirect_to(@measurement, notice: 'Field(s) '+fields_to_update.join(', ')+' propagated successfully.')
+    series.keys.each {|name| Series.find_by(universe: @measurement.universe, name: name).update_attributes new_vals_hash }
+    redirect_to(@measurement, notice: 'Field(s) ' + fields_to_update.join(', ') + ' propagated successfully.')
   end
 
   private

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -119,7 +119,7 @@ class MeasurementsController < ApplicationController
       return
     end
     new_vals_hash = fields_to_update.map{|f| [translate(f), @measurement.read_attribute(f)] }.to_h
-    series.keys.each {|name| Series.find_by(universe: @measurement.universe, name: name).update_attributes new_vals_hash }
+    series.keys.each {|name| Series.find_by(universe: @measurement.universe, name: name).update_attributes(new_vals_hash) }
     redirect_to(@measurement, notice: 'Field(s) ' + fields_to_update.join(', ') + ' propagated successfully.')
   end
 

--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -146,11 +146,11 @@ class DbedtUpload < ApplicationRecord
       parent_indicator_id = row[4]
       parent_label = "DBEDT_#{parent_indicator_id}"
       if row[2].blank?
-        category = Category.find_by(meta: "DBEDT_#{indicator_id}")
+        category = Category.find_by(universe: 'DBEDT', meta: "DBEDT_#{indicator_id}")
         if category.nil?
           ancestry = Category.find_by(universe: 'DBEDT', ancestry: nil).id rescue raise('No DBEDT root category found')
           unless parent_indicator_id.nil?
-            parent_category = Category.find_by(meta: parent_label)
+            parent_category = Category.find_by(universe: 'DBEDT', meta: parent_label)
             unless parent_category.nil?
               ancestry = parent_category.ancestry + '/' + parent_category.id.to_s
             end
@@ -168,14 +168,14 @@ class DbedtUpload < ApplicationRecord
 
       # data_list_measurements entry
       unless row[2].blank?
-        data_list = DataList.find_by(name: parent_label)
+        data_list = DataList.find_by(universe: 'DBEDT', name: parent_label)
         if data_list.nil?
           data_list = DataList.create(name: parent_label, universe: 'DBEDT')
           unless category.nil?
             category.update data_list_id: data_list.id
           end
         end
-        measurement = Measurement.find_by(prefix: "DBEDT_#{indicator_id}")
+        measurement = Measurement.find_by(universe: 'DBEDT', prefix: "DBEDT_#{indicator_id}")
         if measurement.nil?
           measurement = Measurement.create(
               universe: 'DBEDT',
@@ -229,7 +229,7 @@ class DbedtUpload < ApplicationRecord
       (geo_handle, geo_fips) = get_geo_codes(region)
       name = Series.build_name(prefix, geo_handle, row[4])
       if current_measurement.nil? || current_measurement.prefix != prefix
-        current_measurement = Measurement.find_by prefix: prefix
+        current_measurement = Measurement.find_by(universe: 'DBEDT', prefix: prefix)
         if current_measurement.nil?
           current_measurement = Measurement.create(
               universe: 'DBEDT',
@@ -248,7 +248,7 @@ class DbedtUpload < ApplicationRecord
         unit_str = row[8] && row[8].to_ascii.strip
         unit = (unit_str.blank? || unit_str.downcase == 'none') ? nil : Unit.get_or_new(unit_str, 'DBEDT')
 
-        current_series = Series.find_by name: name
+        current_series = Series.find_by(universe: 'DBEDT', name: name)
         if current_series.nil?
           current_series = Series.create_new(
               universe: 'DBEDT',
@@ -269,7 +269,7 @@ class DbedtUpload < ApplicationRecord
           current_measurement.series << current_series
           Rails.logger.debug { "added series #{current_series.name} to measurement #{current_measurement.prefix}" }
         end
-        current_data_source = DataSource.find_by eval: "DbedtUpload.load(#{id}, #{current_series.id})"
+        current_data_source = DataSource.find_by(universe: 'DBEDT', eval: "DbedtUpload.load(#{id}, #{current_series.id})")
         if current_data_source.nil?
           current_data_source = DataSource.create(
               universe: 'DBEDT',

--- a/app/models/forecast_snapshot.rb
+++ b/app/models/forecast_snapshot.rb
@@ -6,10 +6,10 @@ class ForecastSnapshot < ApplicationRecord
 
   # Get series name from series mnemonic
   def retrieve_name(name)
-    s = Series.find_by(name: name)
+    s = Series.find_by(universe: 'UHERO', name: name)
     if s.nil?
       prefix = name[/[^@]*/]
-      like_series = Series.find_by("name LIKE '#{prefix}@%'")
+      like_series = Series.find_by("universe = 'UHERO' and name LIKE '#{prefix}@%'")
       return like_series ? like_series.dataPortalName : 'NO_NAME_FOUND'
     end
     s.aremos_series.description.titlecase
@@ -17,7 +17,7 @@ class ForecastSnapshot < ApplicationRecord
 
   # Get series percent from series mnemonic
   def retrieve_percent(name)
-    s = Series.find_by(name: name)
+    s = Series.find_by(universe: 'UHERO', name: name)
     if s.nil?
       return ''
     end
@@ -26,14 +26,14 @@ class ForecastSnapshot < ApplicationRecord
 
   # Get series units
   def retrieve_units(prefix)
-    m = Measurement.find_by(prefix: prefix.chomp('NS'))
+    m = Measurement.find_by(universe: 'UHERO', prefix: prefix.chomp('NS'))
     return 'Values' if m.nil?
     m.unit ? m.unit.short_label : 'Values'
   end
 
   # Get series ID for each series
   def retrieve_series_id(name)
-    s = Series.find_by(name: name)
+    s = Series.find_by(universe: 'UHERO', name: name)
     if s.nil?
       return ''
     end
@@ -42,7 +42,7 @@ class ForecastSnapshot < ApplicationRecord
 
   # Check if series is restricted, if yes, set restricted to false (allows series to be visible in Data Portal)
   def unrestrict_series(name)
-    s = Series.find_by(name: name)
+    s = Series.find_by(universe: 'UHERO', name: name)
     if !s.nil? && s.restricted
       s.update_attributes({:restricted => false})
     end

--- a/app/models/nta_upload.rb
+++ b/app/models/nta_upload.rb
@@ -246,7 +246,7 @@ class NtaUpload < ApplicationRecord
                                                 geotype: 'incgrp4' }).id
                      else nil
                    end
-            current_series = Series.find_by(name: series_name) ||
+            current_series = Series.find_by(universe: 'NTA', name: series_name) ||
                              Series.create_new(
                                universe: 'NTA',
                                name: series_name,
@@ -258,7 +258,7 @@ class NtaUpload < ApplicationRecord
                                source_id: measurement.source_id
                            )
             eval_str = "NtaUpload.load(#{id}, #{current_series.id})"
-            current_data_source = DataSource.find_by(eval: eval_str)
+            current_data_source = DataSource.find_by(universe: 'NTA', eval: eval_str)
             if current_data_source.nil?
               current_data_source = DataSource.create(
                 universe: 'NTA',


### PR DESCRIPTION
Followup to universe split: cannot look up series by unique name now, so needed to added universe to many `Foo.find_by(name: ...)` method calls.