### PR TITLE
Forecast snapshots file system access broken (UA-1183)

### DIFF
--- a/app/controllers/data_lists_controller.rb
+++ b/app/controllers/data_lists_controller.rb
@@ -126,7 +126,7 @@ class DataListsController < ApplicationController
   end
 
   def create
-    properties = data_list_params.merge(created_by: current_user.id, updated_by: current_user.id, owned_by: current_user.id)
+    properties = data_list_params.merge(created_by: current_user.id, updated_by: current_user.id)
     category = Category.find(params[:category_id].to_i) rescue nil
     if category
       properties.merge!(universe: category.universe)
@@ -151,7 +151,7 @@ class DataListsController < ApplicationController
 
   def update
     respond_to do |format|
-      if @data_list.update! data_list_params.merge({ :updated_by => current_user.id })
+      if @data_list.update! data_list_params.merge(updated_by: current_user.id)
         format.html { redirect_to(@data_list, :notice => 'Data list was successfully updated.') }
         format.xml  { head :ok }
       else

--- a/app/helpers/data_points_helper.rb
+++ b/app/helpers/data_points_helper.rb
@@ -2,6 +2,6 @@ module DataPointsHelper
 
   def dp_superscript(dp)
     days_since_creation = (Time.now.to_date - dp.created_at.to_date).to_i
-    "#{days_since_creation}#{'(ph)' if dp.pseudo_history?}"
+    "#{days_since_creation}#{'(ph)' if dp.pseudo_history?}"  ## pseudo_history is a model attribute, not a code method
   end
 end

--- a/app/models/forecast_snapshot.rb
+++ b/app/models/forecast_snapshot.rb
@@ -99,7 +99,7 @@ class ForecastSnapshot < ApplicationRecord
     history_tsd_filename ? delete_file_from_disk(history_tsd_filename) : true
   end
 
-  private
+private
   def write_file_to_disk(name, content)
     begin
       File.open(path(name), 'wb') { |f| f.write(content) }
@@ -139,8 +139,8 @@ class ForecastSnapshot < ApplicationRecord
   end
 
   def tsd_rel_filepath(name)
-    string = self.created_at.to_s+'_'+self.id.to_s+'_'+name
+    string = self.created_at.utc.to_s+'_'+self.id.to_s+'_'+name
     hash = Digest::MD5.new << string
     File.join('tsd_files', hash.to_s+'_'+name)
-    end
+  end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1008,15 +1008,7 @@ class Series < ApplicationRecord
     end
     self.delete
   end
-    
-  def last_data_added
-    self.data_points.order(:created_at).last.created_at
-  end
-  
-  def last_data_added_string
-    last_data_added.strftime('%B %e, %Y')
-  end
-  
+
   def Series.get_all_series_by_eval(patterns)
     if patterns.class == String
       patterns = [patterns]

--- a/app/models/tsd_file.rb
+++ b/app/models/tsd_file.rb
@@ -315,7 +315,7 @@ private
   end
 
   def tsd_rel_filepath(name)
-    string = self.forecast_snapshot.created_at.to_s+'_'+self.forecast_snapshot_id.to_s+'_'+name
+    string = self.forecast_snapshot.created_at.utc.to_s+'_'+self.forecast_snapshot_id.to_s+'_'+name
     hash = Digest::MD5.new << string
     File.join(TsdFile.path_prefix, hash.to_s+'_'+name)
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -85,7 +85,7 @@ every 1.day, :at => "#{hour.to_i+5}:50 am" do
   rake :aremos_exports
 end
 
-every 1.day, :at => "#{hour.to_i+5}:55 am" do
+every 1.day, :at => "#{hour.to_i+7}:50 am" do
   rake :tsd_exports
 end
 


### PR DESCRIPTION
Main purpose of this PR was to fix the problem with FS, which was that I had just changed udaman to use local time by default, with timezone specified in config, rather than having code convert to localtime for display all the time. However FS broke because create times (in UTC) were being hashed to create filesystem paths. I added `.utc` back to that code so that those file paths would remain using UTC for hashing.

There are a few other cleanup things here as well, including preventing data lists from always being marked as owned by the user creating them, and changing the scheduled run time of tsd exports each morning.