### PR TITLE
Get rid of unitsLabel & unitsLabelShort

### DIFF
--- a/app/models/dbedt_upload.rb
+++ b/app/models/dbedt_upload.rb
@@ -258,8 +258,6 @@ class DbedtUpload < ApplicationRecord
               description: row[1],
               dataPortalName: row[1],
               unit_id: unit && unit.id,
-              unitsLabel: unit_str,
-              unitsLabelShort: unit_str,
               source_id: source && source.id,
               decimals: row[10],
               units: 1


### PR DESCRIPTION
Turned out to be simple. Shoulda done long ago.
Migration to remove the unused columns will be done along with UA-1174.