### PR TITLE
Fix for deprecation warning

### DIFF
--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -80,8 +80,7 @@ private
   def new_span_id(node)
     require 'digest/md5'
     return if node.is_childless?
-    seed_string = node.ancestors.map{|a| a.name }.concat([node.name]).to_s
-    hash = Digest::MD5.new << seed_string
+    hash = Digest::MD5.new << node.unique_id_string
     'cat_' + hash.to_s[0..9]
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -60,6 +60,10 @@ class Category < ApplicationRecord
     end
   end
 
+  def unique_id_string
+    ancestors.map(&:name).push(self.name).join('+')
+  end
+
   def Category.get_all(except = nil)
     if except
       Category.where("universe = 'UHERO' AND id != ?", except).order(:name)


### PR DESCRIPTION
> DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "coalesce(categories.ancestry, '')". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from new_span_id at /home/deploy/udaman/app/helpers/categories_helper.rb:83)

This points clearly to line 83 of the helpers file (`seed_string`), but it is not 100% clear to me exactly what the problem is with that line. Maybe it has something to do with how Rails converts things to SQL. In any event, I don't know how to reproduce this warning message... don't remember where I got it in the first place. Since I can't reproduce it, and can't test it, I'm just using "programmer's sense" to put in a fix that will probably solve the problem and avoid the warning. Worst case, it's not fixed, and breaks when we upgrade to 6.0, so I'll fix it for real then.