### PR TITLE
Clustermapping dateranges

### DIFF
--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -99,6 +99,7 @@ class DataHtmlParser
   end
 
   def get_clustermapping_series(dataset, parameters)
+    parameters[2] = expand_date_range(parameters[2]) if parameters[2].include? ':'
     query_params = parameters.map(&:to_s).join('/')
     @url = "http://clustermapping.us/data/region/#{query_params}"
     Rails.logger.info { "Getting data from Clustermapping API: #{@url}" }
@@ -114,6 +115,11 @@ class DataHtmlParser
       end
     end
     new_data
+  end
+
+  def expand_date_range(date_range)
+    split_dates = date_range.split(":")
+    (split_dates[0]..split_dates[1]).to_a.join(',')
   end
 
   def get_eia_series(parameter)

--- a/app/views/help/data_sources.html.erb
+++ b/app/views/help/data_sources.html.erb
@@ -73,7 +73,7 @@ Series.load_from_eia('ELEC.GEN.ALL-HI-99.A')
   Honolulu County: 15003
   Kauai County: 15007
 </pre>
-<p>Year may be "all", a single year, or a range separated by a semicolon, and cluster is the Cluster ID (list of <a target="_balnk" rel="noopener" href="http://clustermapping.us/data/meta/clusters">Cluster IDs</a>)</p>
+<p>Year may be "all", a single year, or a range separated by a colon, and cluster is the Cluster ID (list of <a target="_balnk" rel="noopener" href="http://clustermapping.us/data/meta/clusters">Cluster IDs</a>)</p>
 <p>
   Example <strong>eval</strong>
 </p>

--- a/app/views/help/data_sources.html.erb
+++ b/app/views/help/data_sources.html.erb
@@ -73,11 +73,13 @@ Series.load_from_eia('ELEC.GEN.ALL-HI-99.A')
   Honolulu County: 15003
   Kauai County: 15007
 </pre>
-<p>Year may be "all" or a single year, and cluster is the Cluster ID (list of <a target="_balnk" rel="noopener" href="http://clustermapping.us/data/meta/clusters">Cluster IDs</a>)</p>
+<p>Year may be "all", a single year, or a range separated by a semicolon, and cluster is the Cluster ID (list of <a target="_balnk" rel="noopener" href="http://clustermapping.us/data/meta/clusters">Cluster IDs</a>)</p>
 <p>
   Example <strong>eval</strong>
 </p>
 
 <pre>
 Series.load_from_clustermapping('lq_tf', ["state", "15", "all", "13"])
+Series.load_from_clustermapping('lq_tf', ["state", "15", "2000", "13"])
+Series.load_from_clustermapping('lq_tf', ["state", "15", "1998:2016", "13"])
 </pre>


### PR DESCRIPTION
This makes requesting a range of data from the clustermapping API cleaner. Date ranges can be specified with a starting and ending year separated by a colon.

@kotodharma When you have a chance could you update the load statements for the current clustermapping series on Udaman? Right now they look like `Series.load_from_clustermapping('lq_tf', ["state", "15", "all", "13"])` The `"all"` should be changed to `"1998:2016"`. 