### PR TITLE
Series deletion (UA-1195)

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -110,7 +110,10 @@ class SeriesController < ApplicationController
     @ytd_chg = @series.ytd_percentage_change params[:id]
     @lvl_chg = @series.absolute_change params[:id]
     @desc = @as.nil? ? 'No Aremos Series' : @as.description
-    @dsas = @series.data_source_actions
+    @dsas = []
+    @series.data_sources.each do |ds|
+      @dsas.concat ds.data_source_actions
+    end
     return if no_render
 
     respond_to do |format|

--- a/app/helpers/series_helper.rb
+++ b/app/helpers/series_helper.rb
@@ -126,7 +126,7 @@ module SeriesHelper
     alt_univs = { 'UHERO' => %w{COH}, 'DBEDT' => %w{UHERO COH} }  ## Yes, these relations are hardcoded. So sue me.
     links = []
     seen = {}
-    series.get_aliases.sort_by{|x| [x.is_primary? ? 0 : 1, x.universe] }.each do |s|
+    series.aliases.sort_by{|x| [x.is_primary? ? 0 : 1, x.universe] }.each do |s|
       links.push link_to(universe_label(s), { controller: :series, action: :show, id: s.id }, title: s.name)
       seen[s.universe] = true
     end

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -9,7 +9,7 @@ class DataSource < ApplicationRecord
   has_many :data_points, dependent: :delete_all
   has_many :data_source_downloads, dependent: :delete_all
   has_many :downloads, -> {distinct}, through: :data_source_downloads
-  has_many :data_source_actions
+  has_many :data_source_actions, dependent: :delete_all
 
   composed_of   :last_run,
                 :class_name => 'Time',

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -21,7 +21,7 @@ class Series < ApplicationRecord
 
   belongs_to :xseries, inverse_of: :series
   accepts_nested_attributes_for :xseries
-  delegate_missing_to :xseries  ## methods that Series does not 'respond_to?' should be tried against the contained Xseries
+  delegate_missing_to :xseries  ## methods that Series does not 'respond_to?' are tried against the contained Xseries
 
 ##  has_many :data_points, through: :xseries
   has_many :data_sources, inverse_of: :series, dependent: :destroy

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1344,7 +1344,7 @@ class Series < ApplicationRecord
   end
 
   def last_rites
-    ### The use of throw(:abort) prevents the series from being destroyed
+    ### The use of throw(:abort) prevents the object from being destroyed
     throw(:abort) if is_primary? && !aliases.empty?
     begin
       stmt = ActiveRecord::Base.connection.raw_connection.prepare(<<~MYSQL)
@@ -1355,6 +1355,9 @@ class Series < ApplicationRecord
     rescue
       Rails.logger.warn { "Unable to delete public data points before destruction of series <#{self}> id=#{id}" }
       throw(:abort)
+    end
+    if is_primary?
+      xseries.destroy!
     end
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1356,6 +1356,7 @@ class Series < ApplicationRecord
       Rails.logger.warn { "Unable to delete public data points before destruction of series <#{self}> id=#{id}" }
       throw(:abort)
     end
+    self.update_attributes(scratch: 90909)  ## a code to indicate this series is in process of destruction
     if is_primary?
       xseries.destroy!
     end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -74,12 +74,12 @@ class Series < ApplicationRecord
     Series.get_all_uhero.pluck(:name)
   end
 
-  def Series.get(name)
-    Series.parse_name(name) && Series.where(name: name).first
+  def Series.get(name, universe = 'UHERO')
+    Series.parse_name(name) && Series.where(universe: universe, name: name).first
   end
 
-  def Series.get_or_new(series_name)
-    Series.get(series_name) || Series.create_new(name: series_name)
+  def Series.get_or_new(series_name, universe = 'UHERO')
+    Series.get(series_name, universe) || Series.create_new(universe: universe, name: series_name)
   end
 
   def Series.bulk_create(definitions)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1359,21 +1359,12 @@ class Series < ApplicationRecord
     end
     if is_primary?
       xseries.update_attributes(primary_series_id: nil)  ## to avoid failure on foreign key constraint
+      self.update_attributes(scratch: 90909)  ## a flag to tell next callback to delete the xseries
     end
-=begin
-    self.update_attributes(scratch: 90909)  ## a flag to indicate this Series object is in process of destruction
-    if is_primary?
-      xs = xseries
-      self.update_attributes(xseries_id: 0)  ## avoid the failure on foreign key constraint that would happen otherwise
-##      self.reload
-      xs.destroy!
-    end
-=end
   end
 
   def post_mortem
-    if is_primary?
-      Rails.logger.warn { ">>>>>>>>>>>>>>>>> right here: #{self.xseries_id}|#{self.xseries.frequency}|" }
+    if scratch == 90909
       xseries.destroy!
     end
   end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1356,7 +1356,7 @@ class Series < ApplicationRecord
       Rails.logger.warn { "Unable to delete public data points before destruction of series <#{self}> id=#{id}" }
       throw(:abort)
     end
-    self.update_attributes(scratch: 90909)  ## a code to indicate this series is in process of destruction
+    self.update_attributes(scratch: 90909)  ## a code to indicate this Series object is in process of destruction
     if is_primary?
       xseries.destroy!
     end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1356,7 +1356,7 @@ class Series < ApplicationRecord
       Rails.logger.warn { "Unable to delete public data points before destruction of series <#{self}> id=#{id}" }
       throw(:abort)
     end
-    self.update_attributes(scratch: 90909)  ## a code to indicate this Series object is in process of destruction
+    self.update_attributes(scratch: 90909)  ## a flag to indicate this Series object is in process of destruction
     if is_primary?
       xseries.destroy!
     end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -16,6 +16,7 @@ class Series < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { scope: :universe }
   validate :source_link_is_valid
+  before_destroy :last_rites, prepend: true
 
   belongs_to :xseries, inverse_of: :series
   accepts_nested_attributes_for :xseries
@@ -218,7 +219,7 @@ class Series < ApplicationRecord
     xseries.primary_series
   end
 
-  def get_aliases
+  def aliases
     Series.where('xseries_id = ? and id <> ?', xseries_id, id)
   end
 
@@ -1340,6 +1341,10 @@ class Series < ApplicationRecord
 
   def source_link_is_valid
     source_link.blank? || valid_url(source_link) || errors.add(:source_link, 'is not a valid URL')
+  end
+
+  def last_rites
+    throw(:abort) if is_primary? && !aliases.empty?
   end
 
 private

--- a/app/models/xseries.rb
+++ b/app/models/xseries.rb
@@ -9,10 +9,8 @@ class Xseries < ApplicationRecord
   serialize :factors, Hash
 
   def last_rites
-    Rails.logger.warn { ">>>>>>>>>>>>>>>>> entering last rites: #{primary_series_id}|" }
     primary_series.reload rescue return
     ### The use of throw(:abort) prevents the object from being destroyed
-    Rails.logger.warn { ">>>>>>>>>>>>>>>>> now here" }
     throw(:abort)  ## this line is only reached if primary_series still exists
   end
 end

--- a/app/models/xseries.rb
+++ b/app/models/xseries.rb
@@ -1,5 +1,6 @@
 class Xseries < ApplicationRecord
   include Cleaning
+  before_destroy :last_rites, prepend: true
 
   has_many :series, inverse_of: :xseries
   has_one :primary_series, class_name: 'Series'
@@ -7,4 +8,8 @@ class Xseries < ApplicationRecord
 
   serialize :factors, Hash
 
+  def last_rites
+    ### The use of throw(:abort) prevents the object from being destroyed
+    throw(:abort) if somethingggggggg
+  end
 end

--- a/app/models/xseries.rb
+++ b/app/models/xseries.rb
@@ -9,7 +9,10 @@ class Xseries < ApplicationRecord
   serialize :factors, Hash
 
   def last_rites
+    Rails.logger.warn { ">>>>>>>>>>>>>>>>> entering last rites: #{primary_series_id}|" }
+    primary_series.reload rescue return
     ### The use of throw(:abort) prevents the object from being destroyed
-    throw(:abort) if primary_series.scratch != 90909  ## check Series.last_rites for meaning of this
+    Rails.logger.warn { ">>>>>>>>>>>>>>>>> now here" }
+    throw(:abort)  ## this line is only reached if primary_series still exists
   end
 end

--- a/app/models/xseries.rb
+++ b/app/models/xseries.rb
@@ -10,6 +10,6 @@ class Xseries < ApplicationRecord
 
   def last_rites
     ### The use of throw(:abort) prevents the object from being destroyed
-    throw(:abort) if somethingggggggg
+    throw(:abort) if primary_series.scratch != 90909  ## check Series.last_rites for meaning of this
   end
 end

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -15,13 +15,14 @@
 							:controller => 'data_sources',
 							:action => 'clear',
 							:id => ds.id} unless myeval.blank?
-					%>&nbsp;|&nbsp;<%= 
-						link_to 'delete', {
-							:controller => 'data_sources',
-							:action => 'delete', 
-							:id => ds.id },
-							data: { :confirm => "Delete definition #{ds.id}: Are you sure??" }
-					%><br/>
+					%>&nbsp
+          <% if current_user.admin_user? %>
+            |&nbsp;<%= link_to 'delete', {
+                :controller => 'data_sources',
+                :action => 'delete',
+                :id => ds.id },
+                data: { :confirm => "Delete definition #{ds.id}: Are you sure??" } %>
+          <% end %><br/>
           <% if myeval =~ /load_from_download/ %>
              <%= link_to 'reset', { controller: :data_sources, action: :reset, id: ds.id }%>&nbsp;|
           <% end %>

--- a/app/views/series/_source_list.html.erb
+++ b/app/views/series/_source_list.html.erb
@@ -15,7 +15,7 @@
 							:controller => 'data_sources',
 							:action => 'clear',
 							:id => ds.id} unless myeval.blank?
-					%>&nbsp
+					%>&nbsp;
           <% if current_user.admin_user? %>
             |&nbsp;<%= link_to 'delete', {
                 :controller => 'data_sources',


### PR DESCRIPTION
Callbacks to make sure everything related is removed properly when deleting a series, and also that nothing is deleted accidentally if it shouldn't be.

Also (unrelated), make the Definition delete link on the Series display page only visible to `admin_user` people.