### PR TITLE
Fix geography name ordering in data portal (UA-1236)

### DIFF
--- a/db/migrate/220170413025757_add_list_order_to_geographies.rb
+++ b/db/migrate/220170413025757_add_list_order_to_geographies.rb
@@ -1,0 +1,6 @@
+class AddListOrderToGeographies < ActiveRecord::Migration[5.2]
+  def change
+    change_column :geographies, :handle, :string, after: :fips    ### just to move this to a better "position" in db view
+    add_column :geographies, :list_order, :integer, after: :display_name_short
+  end
+end


### PR DESCRIPTION
Also move the `handle` further to the left for better human consumption.