### PR TITLE
Implement `mtd_avg` function and apply to MTD calculations (UA-1276)

### DIFF
--- a/app/lib/series_arithmetic.rb
+++ b/app/lib/series_arithmetic.rb
@@ -241,34 +241,24 @@ module SeriesArithmetic
     mtd_sum = 0
     mtd_month = nil
     data.sort.each do |date, value|
-      month = date.month
-      if month == mtd_month
+      if date.month == mtd_month
         mtd_sum += value
       else
         mtd_sum = value
-        mtd_month = month
+        mtd_month = date.month
       end
       new_series_data[date] = mtd_sum
     end
-    new_transformation("Month to Date sum of #{self}", new_series_data)
+    new_transformation("Month To Date sum of #{self}", new_series_data)
   end
 
   def mtd_avg
     return all_nil unless frequency == 'day'
-    new_series_data = {}
-    mtd_sum = 0
-    mtd_month = nil
-    data.sort.each do |date, value|
-      month = date.month
-      if month == mtd_month
-        mtd_sum += value
-      else
-        mtd_sum = value
-        mtd_month = month
-      end
-      new_series_data[date] = mtd_sum
+    avg_series = {}
+    mtd_sum.data.sort.each do |date, value|
+      avg_series[date] = value / date.day
     end
-    new_transformation("Month to Date average of #{self}", new_series_data)
+    new_transformation("Month To Date average of #{self}", avg_series)
   end
 
   def mtd

--- a/app/lib/series_arithmetic.rb
+++ b/app/lib/series_arithmetic.rb
@@ -262,9 +262,13 @@ module SeriesArithmetic
   end
 
   def mtd
+    mtd_sum.yoy
+  end
+
+  def mtd_foo
     mtd_avg.yoy
   end
-  
+
   def ytd_sum
     return all_nil unless %w(day week).index(frequency).nil?
     new_series_data = {}

--- a/app/lib/series_arithmetic.rb
+++ b/app/lib/series_arithmetic.rb
@@ -239,14 +239,14 @@ module SeriesArithmetic
     return all_nil unless frequency == 'day'
     new_series_data = {}
     mtd_sum = 0
-    mtd_month = nil
+    track_month = nil
     data.sort.each do |date, value|
-      if date.month == mtd_month
-        mtd_sum += value
-      else
-        mtd_sum = value
-        mtd_month = date.month
+      if date.month != track_month
+        raise "mtd_sum: month does not start on the 1st (date=#{date})" unless date.day == 1
+        track_month = date.month
+        mtd_sum = 0
       end
+      mtd_sum += value
       new_series_data[date] = mtd_sum
     end
     new_transformation("Month-To-Date sum of #{self}", new_series_data)

--- a/app/lib/series_arithmetic.rb
+++ b/app/lib/series_arithmetic.rb
@@ -249,7 +249,7 @@ module SeriesArithmetic
       end
       new_series_data[date] = mtd_sum
     end
-    new_transformation("Month To Date sum of #{self}", new_series_data)
+    new_transformation("Month-To-Date sum of #{self}", new_series_data)
   end
 
   def mtd_avg
@@ -258,7 +258,7 @@ module SeriesArithmetic
     mtd_sum.data.sort.each do |date, value|
       avg_series[date] = value / date.day
     end
-    new_transformation("Month To Date average of #{self}", avg_series)
+    new_transformation("Month-To-Date average of #{self}", avg_series)
   end
 
   def mtd

--- a/app/lib/series_arithmetic.rb
+++ b/app/lib/series_arithmetic.rb
@@ -242,10 +242,11 @@ module SeriesArithmetic
     track_month = nil
     data.sort.each do |date, value|
       if date.month != track_month
-        raise "mtd_sum: month does not start on the 1st (date=#{date})" unless date.day == 1
+        raise "mtd_sum: month does not start on the 1st (#{date.year}/#{date.month})" unless date.day == 1
         track_month = date.month
         mtd_sum = 0
       end
+      ##### should we be checking each day transition to see if there are missing days?
       mtd_sum += value
       new_series_data[date] = mtd_sum
     end
@@ -262,10 +263,6 @@ module SeriesArithmetic
   end
 
   def mtd
-    mtd_sum.yoy
-  end
-
-  def mtd_foo
     mtd_avg.yoy
   end
 

--- a/app/lib/series_arithmetic.rb
+++ b/app/lib/series_arithmetic.rb
@@ -239,15 +239,17 @@ module SeriesArithmetic
     return all_nil unless frequency == 'day'
     new_series_data = {}
     mtd_sum = 0
+    last_day = 0
     track_month = nil
     data.sort.each do |date, value|
       if date.month != track_month
-        raise "mtd_sum: month does not start on the 1st (#{date.year}/#{date.month})" unless date.day == 1
         track_month = date.month
         mtd_sum = 0
+        last_day = 0
       end
-      ##### should we be checking each day transition to see if there are missing days?
+      raise "mtd_sum: gap in daily data preceding #{date}" if (date.day - last_day) > 1
       mtd_sum += value
+      last_day = date.day
       new_series_data[date] = mtd_sum
     end
     new_transformation("Month-To-Date sum of #{self}", new_series_data)

--- a/app/lib/series_arithmetic.rb
+++ b/app/lib/series_arithmetic.rb
@@ -235,7 +235,6 @@ module SeriesArithmetic
     new_transformation("Annualized Percentage Change of #{name}", new_series_data)
   end
   
-  #should unify these a bit
   def mtd_sum
     return all_nil unless frequency == 'day'
     new_series_data = {}
@@ -251,11 +250,29 @@ module SeriesArithmetic
       end
       new_series_data[date] = mtd_sum
     end
-    new_transformation("Month to Date sum of #{name}", new_series_data)
+    new_transformation("Month to Date sum of #{self}", new_series_data)
   end
-  
+
+  def mtd_avg
+    return all_nil unless frequency == 'day'
+    new_series_data = {}
+    mtd_sum = 0
+    mtd_month = nil
+    data.sort.each do |date, value|
+      month = date.month
+      if month == mtd_month
+        mtd_sum += value
+      else
+        mtd_sum = value
+        mtd_month = month
+      end
+      new_series_data[date] = mtd_sum
+    end
+    new_transformation("Month to Date average of #{self}", new_series_data)
+  end
+
   def mtd
-    mtd_sum.yoy
+    mtd_avg.yoy
   end
   
   def ytd_sum

--- a/app/lib/series_arithmetic.rb
+++ b/app/lib/series_arithmetic.rb
@@ -92,7 +92,7 @@ module SeriesArithmetic
     #raise SeriesArithmeticException if self.frequency.nil? or other_series.frequency.nil?
   end
   
-  def rebase(year=nil)
+  def rebase(year = nil)
     unless year.nil?
       year = Date.parse(year).year
     end
@@ -139,7 +139,7 @@ module SeriesArithmetic
     end
   end
 
-  def absolute_change(id=nil)
+  def absolute_change(id = nil)
     return faster_change(id) unless id.nil?
     new_series_data = {}
     last = nil
@@ -186,17 +186,17 @@ module SeriesArithmetic
     new_transformation("All nil for dates in #{name}", new_series_data)
   end
   
-  def yoy(id=nil)
+  def yoy(id = nil)
     annualized_percentage_change id
   end
   
-  def annualized_percentage_change(id=nil)
+  def annualized_percentage_change(id = nil)
     day_based_yoy id
   end
   
   #just going to leave out the 29th on leap years for now
   def day_based_yoy(id)
-    return all_nil unless ['week'].index(frequency).nil?
+    return all_nil if frequency == 'week'
     return faster_yoy id unless id.nil?
 
     new_series_data = {}
@@ -284,11 +284,11 @@ module SeriesArithmetic
     new_transformation("Year to Date sum of #{name}", new_series_data)
   end
   
-  def ytd(id=nil)
+  def ytd(id = nil)
     ytd_percentage_change id
   end
   
-  def ytd_percentage_change(id=nil)
+  def ytd_percentage_change(id = nil)
     return all_nil unless %w(day week).index(frequency).nil?
     return faster_ytd(id) unless id.nil?
     new_series_data = {}
@@ -340,7 +340,7 @@ module SeriesArithmetic
     annual_diff
   end
   
-  def scaled_yoy_diff(id=nil)
+  def scaled_yoy_diff(id = nil)
     return faster_scaled_yoy_diff(id) unless id.nil?
     new_series_data = {}
     last = {}


### PR DESCRIPTION
Introduce `mtd_avg` function and make this the default for `mtd` rather than `mtd_sum`.
Improve `mtd_sum` to check for gaps in data
Add spaces around `=` in function formal params