### PR TITLE
Clustermap series API loads result in certificate failure (UA-1317)

### DIFF
--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -107,7 +107,7 @@ class DataHtmlParser
     query_params = parameters.map(&:to_s).join('/')
     @url = "http://clustermapping.us/data/region/#{query_params}"
     Rails.logger.debug { "Getting data from Clustermapping API: #{@url}" }
-    @doc = self.download(verify: false)
+    @doc = self.download(verifyssl: false)
     response = JSON.parse self.content
     raise  'Clustermapping API: unknown failure' unless response
     new_data = {}
@@ -247,7 +247,7 @@ class DataHtmlParser
     true
   end
 
-  def download(verify: true)
+  def download(verifyssl: true)
     require 'uri'
     require 'net/http'
     require 'timeout'
@@ -256,7 +256,7 @@ class DataHtmlParser
 
     http = Net::HTTP.new(url.host, url.port)
     http.use_ssl = url.scheme == 'https'
-    unless verify
+    unless verifyssl
       Rails.logger.warn { "Not verifying SSL certs for #{url}" }
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end

--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -107,7 +107,9 @@ class DataHtmlParser
     query_params = parameters.map(&:to_s).join('/')
     @url = "http://clustermapping.us/data/region/#{query_params}"
     Rails.logger.debug { "Getting data from Clustermapping API: #{@url}" }
-    @doc = self.download(verifyssl: false)
+    ## The url should preferably use https, but Clustermapping was having trouble with their SSL certs, and I backed
+    ## the code off to http. Should be restored to https at some time in future, after they get their "stuff" together.
+    @doc = self.download
     response = JSON.parse self.content
     raise  'Clustermapping API: unknown failure' unless response
     new_data = {}
@@ -256,7 +258,7 @@ class DataHtmlParser
 
     http = Net::HTTP.new(url.host, url.port)
     http.use_ssl = url.scheme == 'https'
-    unless verifyssl
+    unless verifyssl  ## can be used for temporary workaround when sites have SSL cert trouble
       Rails.logger.warn { "Not verifying SSL certs for #{url}" }
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end


### PR DESCRIPTION
Clustermapping was having trouble with their SSL config, which I reported to them. After many days, (without answering me) they seem to have removed https service entirely, going back to unsecured connections. At some point we should try to return them to https in our code.