### PR TITLE
No redacted zeroes

### DIFF
--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -90,10 +90,10 @@ class DataHtmlParser
     new_data = {}
     results_data.each do |data_point|
       next unless request_match(filters, data_point)
-      time_period = data_point['TimePeriod']
-      date = grok_date(time_period[0..3], time_period[4..])
+      tp = data_point['TimePeriod']
+      date = grok_date(tp[0..3], tp[4..])
       value = data_point['DataValue'].strip.gsub(',', '') rescue nil  ## nil if DataValue field is entirely missing
-      if data_point['NoteRef'].strip =~ /^\(\w+\)$/i || value.nil?
+      if value.nil? || data_point['NoteRef'].strip =~ /^\(\w+\)$/i
         value = 1.00E+0015  ## marks non-existent data point
       end
       new_data[date] = value.to_f rescue raise("Problem with value at #{date}")

--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -91,10 +91,12 @@ class DataHtmlParser
     results_data.each do |data_point|
       next unless request_match(filters, data_point)
       time_period = data_point['TimePeriod']
-      value = data_point['DataValue']
-      if value && value.gsub(',','').is_numeric?
-        new_data[ grok_date(time_period[0..3], time_period[4..]) ] = value.gsub(',','').to_f
+      date = grok_date(time_period[0..3], time_period[4..])
+      value = data_point['DataValue'].strip.gsub(',', '') rescue nil  ## nil if DataValue field is entirely missing
+      if data_point['NoteRef'].strip =~ /^\(\w+\)$/i || value.nil?
+        value = 1.00E+0015  ## marks non-existent data point
       end
+      new_data[date] = value.to_f rescue raise("Problem with value at #{date}")
     end
     new_data
   end

--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -99,7 +99,7 @@ class DataHtmlParser
       if value.nil? || data_point['NoteRef'] && data_point['NoteRef'].strip =~ /^\(\w+\)$/i
         value = 1.00E+0015  ## marks non-existent data point
       end
-      new_data[date] = value.to_f rescue raise("Problem with value at #{date}")
+      new_data[date] = value.to_f rescue raise("BEA API: Problem with value at #{date}")
     end
     new_data
   end

--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -3,7 +3,7 @@ class DataHtmlParser
 
   def get_fred_series(code, frequency = nil, aggregation_method = nil)
     api_key = ENV['API_KEY_FRED'] || raise('No API key defined for FRED')
-    @url = "http://api.stlouisfed.org/fred/series/observations?api_key=#{api_key}&series_id=#{code}"
+    @url = "https://api.stlouisfed.org/fred/series/observations?api_key=#{api_key}&series_id=#{code}"
     if frequency ## d, w, bw, m, q, sa, a (udaman represents semiannual frequency with S)
       @url += "&frequency=#{frequency.downcase.sub(/^s$/, 'sa')}"
     end
@@ -11,7 +11,7 @@ class DataHtmlParser
       @url += "&aggregation_method=#{aggregation_method.downcase}"
     end
     doc = self.download
-    err = doc.css('error')
+    err = doc.at_css('error')
     raise 'FRED API Error: %s (code=%s)' % [err[:message], err[:code]] if err
 
     data = {}

--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -7,7 +7,7 @@ class DataHtmlParser
     if frequency ## d, w, bw, m, q, sa, a (udaman represents semiannual frequency with S)
       @url += "&frequency=#{frequency.downcase.sub(/^s$/, 'sa')}"
     end
-    if aggregation_method ## avg, sum, eop
+    if aggregation_method ## avg, sum, eop   ### NOTE: this option seems to be ignored by the API now. Review load stmts that use it.
       @url += "&aggregation_method=#{aggregation_method.downcase}"
     end
     doc = self.download

--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -11,6 +11,9 @@ class DataHtmlParser
       @url += "&aggregation_method=#{aggregation_method.downcase}"
     end
     doc = self.download
+    err = doc.css('error')
+    raise '%s (code=%s)' % [err[:message], err[:code]] if err
+
     data = {}
     doc.css('observation').each do |obs|
       next if obs[:value] == '.'

--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -12,7 +12,7 @@ class DataHtmlParser
     end
     doc = self.download
     err = doc.css('error')
-    raise '%s (code=%s)' % [err[:message], err[:code]] if err
+    raise 'FRED API Error: %s (code=%s)' % [err[:message], err[:code]] if err
 
     data = {}
     doc.css('observation').each do |obs|

--- a/app/lib/data_html_parser.rb
+++ b/app/lib/data_html_parser.rb
@@ -96,7 +96,7 @@ class DataHtmlParser
       tp = data_point['TimePeriod']
       date = grok_date(tp[0..3], tp[4..])
       value = data_point['DataValue'].strip.gsub(',', '') rescue nil  ## nil if DataValue field is entirely missing
-      if value.nil? || data_point['NoteRef'].strip =~ /^\(\w+\)$/i
+      if value.nil? || data_point['NoteRef'] && data_point['NoteRef'].strip =~ /^\(\w+\)$/i
         value = 1.00E+0015  ## marks non-existent data point
       end
       new_data[date] = value.to_f rescue raise("Problem with value at #{date}")

--- a/app/models/data_point.rb
+++ b/app/models/data_point.rb
@@ -6,6 +6,10 @@ class DataPoint < ApplicationRecord
   def upd(value, data_source)
     return nil if trying_to_replace_with_nil?(value)
     return nil unless value_or_source_changed?(value, data_source)
+    if value == 1.00E+0015
+      xseries.data_points.where(date: date, current: true).update_all(current: false)
+      return nil
+    end
     create_new_dp(value, data_source)
   end
   

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -345,7 +345,7 @@ class Series < ApplicationRecord
     return false if frequency.freqn <= :year.freqn   ## If freq is annual (or lower), SA makes no sense
     return  true if seasonal_adjustment == 'seasonally_adjusted'
     return false if seasonal_adjustment == 'not_seasonally_adjusted'
-    return false if !fuzzy
+    return false unless fuzzy
     parse_name[:prefix] =~ /SA$/i
   end
 
@@ -354,7 +354,7 @@ class Series < ApplicationRecord
     return false if frequency.freqn <= :year.freqn
     return  true if seasonal_adjustment == 'not_seasonally_adjusted'
     return false if seasonal_adjustment == 'seasonally_adjusted'
-    return false if !fuzzy
+    return false unless fuzzy
     parse_name[:prefix] =~ /NS$/i
   end
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -499,6 +499,7 @@ class Series < ApplicationRecord
     observation_dates -= current_data_points.map(&:date)
     now = Time.now
     observation_dates.each do |date|
+      next if data[date] == 1.00E+0015
       xseries.data_points.create(
         :date => date,
         :value => data[date],

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -436,12 +436,6 @@ class Series < ApplicationRecord
     rescue => e
       raise "Series.eval for #{series_name} failed: #{e.message}"
     end
-#    Series.store(series_name, new_series, new_series.name, eval_statement, priority, no_enforce_fields: no_enforce_fields)
-#  end
-#
-#  def Series.store(series_name, series, desc = nil, eval_statement = nil, priority = 100, no_enforce_fields: false)
-#    desc = series.name if desc.nil?
-#    desc = 'Source Series Name is blank' if desc.blank?
     unless series.frequency == Series.frequency_from_name(series_name)
       raise "Frequency mismatch: attempt to assign name #{series_name} to data with frequency #{series.frequency}"
     end


### PR DESCRIPTION
If an API-loaded data point is redacted for whatever reason in BEA API, then don't load the zero that BEA sends, but instead just let that time period have no current value.